### PR TITLE
Changes to rewrite-rules - bug-fix & consistency with legacy rules.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -93,18 +93,18 @@ RemotePackagesIndexURL=http://packages.ez.no/ezpublish/4.7/4.7.0
         RewriteRule ^/api/ /index_rest.php [L]
         RewriteRule content/treemenu/? /index_treemenu.php [L]
    
-        # If not using cluster
-        RewriteRule ^/var/([^/]+/)?storage/.* - [L]
-        # If using cluster, uncomment the following and comment the previous ones
+        # If using cluster, uncomment the following two lines:
         #RewriteRule ^/var/([^/]+/)?storage/images(-versioned)?/.* /index_cluster.php [L]
         #RewriteRule ^/var/([^/]+/)?cache/(texttoimage|public)/.* /index_cluster.php [L]
-   
+        
+        RewriteRule ^/var/([^/]+/)?storage/.* - [L]
         RewriteRule ^/var/([^/]+/)?cache/(texttoimage|public)/.* - [L]
         RewriteRule ^/design/([^/]+/)?(stylesheets|images|javascript)/.* - [L]
         RewriteRule ^/share/icons/.* - [L]
         RewriteRule ^/extension/[^/]+/design/[^/]+/(lib|stylesheets|images|javascripts?)/.* - [L]
         RewriteRule ^/packages/styles/.+/(stylesheets|images|javascript)/[^/]+/.* - [L]
         RewriteRule ^/packages/styles/.+/thumbnail/.* - [L]
+        RewriteRule ^/var/storage/packages/.* - [L]
         RewriteRule ^/favicon\.ico - [L]
         RewriteRule ^/robots\.txt - [L]
    


### PR DESCRIPTION
The two attached commits fix an issue with the legacy cache in some situations (apache rewrite-rule would not correctly map to the filesystem due to the use of a greedy operator), and re-structures some of the rules to better work with ezp legacy.
