### PR TITLE
Improve documentation: fix speling errors, bad phrases; remove info for developers from README

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -7,7 +7,7 @@ The best way to kickstart is to read the [Symfony2 documentation](http://symfony
 in order to get the basics.
 
 ## Demo bundle
-> "Bundle" is the name for an extension in Symfony.
+> "Bundle" is the name used for an extension in Symfony.
 
 A demo bundle, [EzDemoBundle](https://github.com/ezsystems/ezpublish5/tree/master/src/EzSystems/DemoBundle), is provided
 in the *src/* directory under the *EzSystems* namespace and, among others, provides implementation for the demo design.
@@ -16,7 +16,7 @@ allowing to make some tests and hacking.
 
 The most interesting routes for a start are :
 
-- **eZTest**: Loads a content via the public API and displays it. This content is expected to be a very simple folder with
+- **eZTest**: Loads a content via the Public API and displays it. This content is expected to be a very simple folder with
   *name* and *description* Field Definitions (formerly *content class attributes*).
 - **eZTestWithLegacy**: Includes a legacy template in a new one.
 
@@ -48,10 +48,10 @@ For more information, [check the documentation for this command](http://symfony.
 Any route that is not declared in eZ Publish 5 in an included `routing.yml` and that is not a valid *UrlAlias* will automatically fallback
 to eZ Publish legacy (including admin interface).
 
-This will allow your old modules still to work as before.
+This allows your old modules to work as before out-of-the-box.
 
 ### Developing a controller
-When developing a controller (formerly module), make sure to extend `eZ\Bundle\EzPublishCoreBundle\Controller` instead of the default Symfony one.
+When developing a controller (formerly *module*), make sure to extend `eZ\Bundle\EzPublishCoreBundle\Controller` instead of the default Symfony one.
 This will allow you to take advantage of additional eZ-specific features (like easier Public API access).
 
 Inside an eZ Controller, you can access to the public API by getting the Repository through the `$this->getRepository()` method.
@@ -113,7 +113,7 @@ It is possible to include old templates (**.tpl*) into new ones:
 
 > **Note**
 >
-> Content/Location objects from public API are converted into eZContentObject/eZContentObjectTreeNode objects (re-fetched)
+> Content/Location objects from the Public API are converted into eZContentObject/eZContentObjectTreeNode objects (re-fetched)
 
 ### Run legacy PHP code
 The new kernel still relies on eZ Publish legacy kernel and runs it when needed inside an isolated PHP closure, making it sandboxed.
@@ -137,7 +137,7 @@ $myLegacySetting = $this->getLegacyKernel()->runCallback(
 > `runCallback()` can also take a 2nd argument. Setting to `true` avoids to re-initialize the legacy kernel environment after your call.
 
 ## Limitations / Known issues
-eZ Publish 5 development is still at a very early stage (*pre-alpha*) and as such there are still a lot of limitations and (un)known issues like:
+eZ Publish 5 development is still at an early stage (*pre-beta*) and as such there are still a lot of limitations and (un)known issues like:
 
 - Field templates can't be overridden for now
 - Still a lot of work to do ;-)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 > **Side note for Linux users**:
 > One common issue is that the app/cache and app/logs directories must be writable both by the web server and the command line user.
->  if your web server user is different from your command line user, you can run the following commands just once in your project to ensure that permissions will be setup properly. Change www-data to your web server user:
+> If your web server user is different from your command line user, you can run the following commands just once in your project to ensure that permissions will be set up properly. Change www-data to your web server user:
 > **1. Using ACL on a system that supports chmod +a**
 ```
  $ rm -rf app/cache/*
@@ -10,7 +10,7 @@
  $ sudo chmod +a "www-data allow delete,write,append,file_inherit,directory_inherit" app/cache app/logs
  $ sudo chmod +a "`whoami` allow delete,write,append,file_inherit,directory_inherit" app/cache app/logs
 ```
-> **2. Using Acl on a system that does not support chmod +a**
+> **2. Using ACL on a system that does not support chmod +a**
 > Some systems don't support chmod +a, but do support another utility called setfacl. You may need to enable ACL support on your partition and install setfacl before using it (as is the case with Ubuntu), like so:
 ```
 $ sudo setfacl -R -m u:www-data:rwx -m u:`whoami`:rwx app/cache app/logs
@@ -18,14 +18,14 @@ $ sudo setfacl -dR -m u:www-data:rwx -m u:`whoami`:rwx app/cache app/logs
 ```
 
 ## Glossary
-* /eZ/Publish/5/root/: The file system path where eZ Publish 5 is installed in, like "/home/myuser/www/" or "/var/sites/ezpublish/"
+* /eZ/Publish/5/root/: The filesystem path where eZ Publish 5 is installed in, like "/home/myuser/www/" or "/var/sites/ezpublish/"
 * /eZ/Publish/5/legacy/root/:
 	* "Legacy" aka "Legacy Stack" refers to the eZ Publish 4.x installation which is bundled with eZ Publish 5 inside "app/ezpublish_legacy/"
 	* The Legacy root is thus the root eZ Publish 5 path + the sub path mentioned above, example:  "/var/sites/ezpublish/app/ezpublish_legacy/"
 
 ## Installation
 
-### A: From Archvie (tar.gz)
+### A: From Archive (tar.gz)
 1. Extract the archive
 
    **For upgrading from eZ Publish Enterprise Edition 4.7**: Upgrade documentation can be found on http://doc.ez.no/eZ-Publish/Upgrading/Upgrading-to-5.0/Upgrading-from-4.7-to-5.0
@@ -56,7 +56,7 @@ $ sudo setfacl -dR -m u:www-data:rwx -m u:`whoami`:rwx app/cache app/logs
        php composer.phar install
        ```
 
-## Setup files
+## Set up files
 1. Configure:
     * Copy `app/config/parameters.yml.dist` to `app/config/parameters.yml`
     * Edit `app/config/parameters.yml` and configure
@@ -114,7 +114,7 @@ $ sudo setfacl -dR -m u:www-data:rwx -m u:`whoami`:rwx app/cache app/logs
 
 ## Run eZ Publish
 
-1. *Optional*, **Development ONLY** - Take advantage of PHP 5.4 build-in web server:
+1. *Optional*, **Development ONLY** - Take advantage of PHP 5.4 built-in web server:
 
     ```bash
     php app/console server:run localhost:8000
@@ -125,7 +125,7 @@ $ sudo setfacl -dR -m u:www-data:rwx -m u:`whoami`:rwx app/cache app/logs
 ### Clean installation using Setup wizard
 1. Run Setup wizard:
 
-    There is currently a know issue in eZ Publish 5's Symfony based stack when it comes to Setup wizard, so you will need to execute it directly from the  /eZ/Publish/5/legacy/root/ by exposing that as a internal wirtual host  as well.
+    There is currently a known issue in eZ Publish 5's Symfony based stack when it comes to Setup wizard, so you will need to execute it directly from the /eZ/Publish/5/legacy/root/ by exposing that as a internal virtual host as well.
     This can be done in same way as described on doc.ez.no for Virtual host setups where "eZ Publish" path will be: /eZ/Publish/5/legacy/root/
 
 ##### Troubleshooting during Setup wizard

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 **eZ Publish 5** is a professional PHP CMS (content management system).
 
 It is database, platform and browser independent. Because it is
-browser based it can be used and updated from anywhere as long as you have
+browser based it can be used from anywhere as long as you have
 access to the Internet.
 
 ## Install, Upgrade and Getting started
-For installation & upgrading instructions, see [INSTALL.md](https://github.com/ezsystems/ezpublish5/blob/master/INSTALL.md).
+For installation & upgrade instructions, see [INSTALL.md](https://github.com/ezsystems/ezpublish5/blob/master/INSTALL.md).
 
-To get started on coding, see [GETTING_STARTED.md](https://github.com/ezsystems/ezpublish5/blob/master/GETTING_STARTED.md).
+To get started with coding, see [GETTING_STARTED.md](https://github.com/ezsystems/ezpublish5/blob/master/GETTING_STARTED.md).
 
 ## Requirements
-**eZ Publish 5** meets the same requirements as [Symfony2](http://symfony.com/doc/master/reference/requirements.html),
+**eZ Publish 5** has the same requirements as [Symfony2](http://symfony.com/doc/master/reference/requirements.html),
 plus the [regular eZ Publish 4 ones](http://doc.ez.no/eZ-Publish/Technical-manual/4.x/Installation/Normal-installation/Requirements-for-doing-a-normal-installation).
 
 Minimum PHP version is 5.3.3, but 5.4.x is recommended.
@@ -22,18 +22,19 @@ Minimum PHP version is 5.3.3, but 5.4.x is recommended.
 eZ Publish 5 is **100% data compatible** with version 4 (the same database can be used).
 
 ## Architecture
+
 ### Public API
 **eZ Publish 5** relies on a flexible, layered, service oriented API.
-Public API consistst of the Model (the M in MVC) in eZ Publish 5 and all
-api's related to operations available for thes Models. More info can be found
+The Public API consistst of the Model (the M in MVC) and all
+apis related to operations available for this Model. More info can be found
 in /vendor/ezsystems/ezpublish/Readme.md after installation.
 
 ### HMVC
 eZ Publish 5 is built on top of **[Symfony2](http://symfony.com)** full stack framework, taking advantage of
-every components provided, giving all its **Hierarchical Model View Controller** (aka *HMVC*) power.
+every component provided, including all its **Hierarchical Model View Controller** (aka *HMVC*) power.
 
 ### Chained routing
-A chain router is introduced, allowing to take advantage of declared routes in your `routing.yml` config file as well as
+A chain router is introduced, allowing to take advantage of declared routes in the `routing.yml` config file as well as
 URL aliases to match content (aka *dynamic routing*), or routing fallback to the old eZ Publish 4 modules.
 
 ### Template engine
@@ -43,19 +44,9 @@ The default template engine used by the system is **[Twig](http://twig.sensiolab
 > As Symfony2 allows usage of multiple template engines, it is also possible to do so in eZ Publish 5, but all the
 > content oriented functionality are only available with Twig.
 
-### Legacy template inclusion
-It is possible to include templates from the *legacy kernel* (`*.tpl`) in new twig templates:
-
-```jinja
-{% ez_legacy_include "design:my/old_template.tpl" with {"someVar": "someValue"} %}
-```
-
-### Fallback routing
-A fallback mechanism is provided so that your modules built on top of eZ Publish 4 (aka *Legacy kernel*)
-can still be used in the new architecture.
 
 ## COPYRIGHT
 Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
 
-## LICENCE
+## LICENSE
 http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2


### PR DESCRIPTION
A few side notes (more changes I'd like to implement):
1. getting_started should really not be a doc for develoeprs. Current one should be renamed
2. module_creation as well: it should be moved to a "doc" folders with much more developer's oriented docs
3. in INSTALL, please can we NOT use namespaces for designing a folder: /eZ/Publish/5/root/ is scary and incomprehensible! Jsut call it eZPublishRoot, if it has to be a placeholder for a real value, or even better $eZPublishRoot or <eZPublishRoot>
   4.not sure in install instructions the part about CP make sense at all
