### PR TITLE
Add web/.htaccess to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@
 /web/extension
 /web/share
 /web/var
+/web/.htaccess
 composer.phar


### PR DESCRIPTION
Hi,

I can imagine someone other than me likes to keep his rewrite rules in .htaccess file rather than vhost for easier access, and since I'm OCD in this way and the following

`eddie@abyss ~/ezpublish5 [master] $ git status -s`
`?? web/.htaccess`
`eddie@abyss ~/ezpublish5 [master] $`

extremly bothers me, here goes a patch to add it to gitignore :)
