### PR TITLE
Update `chown` instructions to use super user rights

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,8 +82,8 @@
 
        ```bash
        $ sudo chown -R www-data:www-data ezpublish/{cache,logs,config} ezpublish_legacy/{design,extension,settings,var}
-       $ sudo find {ezpublish/{cache,logs,config},ezpublish_legacy/{design,extension,settings,var}} -type d | xargs chmod -R 775
-       $ sudo find {ezpublish/{cache,logs,config},ezpublish_legacy/{design,extension,settings,var}} -type f | xargs chmod -R 664
+       $ sudo find {ezpublish/{cache,logs,config},ezpublish_legacy/{design,extension,settings,var}} -type d | sudo xargs chmod -R 775
+       $ sudo find {ezpublish/{cache,logs,config},ezpublish_legacy/{design,extension,settings,var}} -type f | sudo xargs chmod -R 664
        ```
 
        D. **Using chmod**


### PR DESCRIPTION
In the first step, the folders are chown'd to the web-server user, but in the next two steps, `xargs` (and by proxy, `chmod`) is still run as the current user, who no longer has the rights to those folders. This will cause `chmod` to fail for all matched files.
