### PR TITLE
added missing info on creating cache folder in legacy ezpublish

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,6 +23,7 @@
        ```bash
        cd /<ezpublish5-root-dir>/
        git clone https://github.com/ezsystems/ezpublish.git ezpublish_legacy
+       cd ezpublish_legacy && mkdir -p var/cache
        ```
 
 3. *Optional* Upgrade an eZ Publish Community Project installation


### PR DESCRIPTION
I got an nesting error when calling the web-setup, due to ezini not able to write the cache-files. Allthough i think this is rather an issue with the structure (i think ezpublish should use ezpublish/cache and not another cache dir in the legacy part of ezpublish), i added the information on the folder missing to the INSTALL.md doc.

What do you think? Do you plan on changing this fact, or do you think it will break the compatibility with legacy installations?
