### PR TITLE
EZP-20422 - router_proxy configuration has been renamed to fragments

### DIFF
--- a/ezpublish/config/config.yml
+++ b/ezpublish/config/config.yml
@@ -4,7 +4,7 @@ imports:
 
 framework:
     esi: ~
-    router_proxy: ~
+    fragments: ~
     #translator:      { fallback: %locale% }
     # The secret parameter is used to generate CSRF tokens
     secret:          %secret%


### PR DESCRIPTION
Hi. As explained in jira, it seems router_proxy has been renamed. 
see https://github.com/symfony/FrameworkBundle/commit/bbede10727830df6bf1e116216183accd4c5f579

Because of this, and as router_proxy is in the config.yml and also enabled, i was having errors because that entry is not recognized now. 
