### PR TITLE
Implemented EZP-20821: Make it possible to configure the front controller without editing it

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -3,26 +3,59 @@
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\ClassLoader\ApcClassLoader;
 
+// Environment is taken from "ENVIRONMENT" variable, if not set, defaults to "prod"
+$environment = getenv( "ENVIRONMENT" );
+if ( $environment === false )
+{
+    $environment = "prod";
+}
+
 $loader = require_once __DIR__ . '/../ezpublish/autoload.php';
 
-// Use APC for autoloading to improve performance:
-// Change 'ezpublish' to a unique prefix in order to prevent cache key conflicts
-// with other applications also using APC.
-/*
-$loader = new ApcClassLoader( 'ezpublish', $loader );
-$loader->register( true );
-*/
+// Depending on the USE_APC_CLASSLOADER environment variable, use APC for autoloading to improve performance.
+// If not set it is not used.
+if ( getenv( "USE_APC_CLASSLOADER" ) )
+{
+    $prefix = getenv( "APC_CLASSLOADER_PREFIX" );
+
+    $loader = new ApcClassLoader( $prefix ?: "ezpublish", $loader );
+    $loader->register( true );
+}
 
 require_once __DIR__ . '/../ezpublish/EzPublishKernel.php';
 require_once __DIR__ . '/../ezpublish/EzPublishCache.php';
 
-$kernel = new EzPublishKernel( 'prod', false );
+// Depending on the USE_DEBUGGING environment variable, tells whether Symfony should be loaded with debugging.
+// If not set it is activated if in "dev" environment.
+if ( ( $useDebugging = getenv( "USE_DEBUGGING" ) ) === false )
+{
+    $useDebugging = $environment === "dev";
+}
+
+$kernel = new EzPublishKernel( $environment, $useDebugging );
 $kernel->loadClassCache();
-// Comment the following line if you use an external reverse proxy (e.g. Varnish)
-$kernel = new EzPublishCache( $kernel );
+
+// Depending on the USE_HTTP_CACHE environment variable, tells whether the internal HTTP Cache mechanism is to be used.
+// If not set it is activated if not in "dev" environment.
+if ( ( $useHttpCache = getenv( "USE_HTTP_CACHE" ) ) === false )
+{
+    $useHttpCache = $environment !== "dev";
+}
+// Load HTTP Cache ...
+if ( $useHttpCache )
+{
+    $kernel = new EzPublishCache( $kernel );
+}
+
 $request = Request::createFromGlobals();
-// If you are behind a trusted reverse proxy, you might set it as "trusted" in order to get correct client IP
-// See HttpFoundation\Request::setTrustedProxies()
+
+// If you are behind one or more trusted reverse proxies, you might want to set them in TRUSTED_PROXIES environment
+// variable in order to get correct client IP
+if ( ( $trustedProxies = getenv( "TRUSTED_PROXIES" ) ) !== false )
+{
+    Request::setTrustedProxies( explode( ",", $trustedProxies ) );
+}
+
 $response = $kernel->handle( $request );
 $response->send();
 $kernel->terminate( $request, $response );

--- a/web/index_dev.php
+++ b/web/index_dev.php
@@ -1,16 +1,3 @@
 <?php
-
-use Symfony\Component\HttpFoundation\Request;
-
-require_once __DIR__ . '/../ezpublish/autoload.php';
-require_once __DIR__ . '/../ezpublish/EzPublishKernel.php';
-require_once __DIR__ . '/../ezpublish/EzPublishCache.php';
-
-$kernel = new EzPublishKernel( 'dev', true );
-$kernel->loadClassCache();
-// Uncomment the following to activate HttpCache.
-//$kernel = new EzPublishCache( $kernel );
-$request = Request::createFromGlobals();
-$response = $kernel->handle( $request );
-$response->send();
-$kernel->terminate( $request, $response );
+putenv( "ENVIRONMENT=dev" );
+require "index.php";


### PR DESCRIPTION
Example of VirtualHost additional config

``` Apache
# Environment.
# Possible values: "prod", "dev", "staging",...
# Defaults to "prod" if omitted
SetEnv ENVIRONMENT "prod"

# Whether to use Symfony's ApcClassLoader.
# Possible values: 0 or 1
# Defaults to 0 if omitted
#SetEnv USE_APC_CLASSLOADER 0

# Prefix used when USE_APC_CLASSLOADER is set to 1.
# Use a unique prefix in order to prevent cache key conflicts
# with other applications also using APC.
# Defaults to "ezpublish" if omitted
#SetEnv APC_CLASSLOADER_PREFIX "ezpublish"

# Whether to use debugging.
# Possible values: 0 or 1
# Defaults to 0 if omitted, unless ENVIRONMENT is set to: "dev"
#SetEnv USE_DEBUGGING 1

# Whether to use Symfony's HTTP Caching.
# Disable it if you are using an external reverse proxy (e.g. Varnish)
# Possible values: 0 or 1
# Defaults to 1 if omitted, unless ENVIRONMENT is set to: "dev"
#SetEnv USE_HTTP_CACHE 0

# Defines the proxies to trust. (See Symfony\Component\HttpFoundation\Request::setTrustedProxies())
# If your application is behind one or more reverse proxies you manage and trust, set them here.
# Separate entries by a comma.
# Example: "proxy1.example.com,proxy2.example.org"
# By default, no trusted proxies are set
#SetEnv TRUSTED_PROXIES "127.0.0.1"
```
