### PR TITLE
Implemented EZP-20841: Provide a router script to use with PHP 5.4 built-in server

### DIFF
--- a/bin/ezrouter.php
+++ b/bin/ezrouter.php
@@ -20,7 +20,7 @@ Usage
 -----
 From your command line, type :
  
-    $ cd /path/to/ezpublish5/root
+    $ cd /path/to/ezpublish5/folder
     $ php ezpublish/console server:run -r ../bin/ezrouter.php localhost:8000
  
 This will start PHP webserver for localhost on port 8000.


### PR DESCRIPTION
This pull-request adds a router script to be used along with PHP 5.4 built-in server, **for development purpose only**.
With it, developers can easily start developing with eZ Publish without the need to configure Apache or any other webserver. Specific rewrite rules are taken into account by the router script.
## Usage

``` bash
php ezpublish/console server:run -r ../bin/ezrouter.php localhost:8000
```

`../bin/ezrouter.php` is needed because with `server:run` command, working directory is `web/`.
