### PR TITLE
Removed: usage of Exception to detect if setup wizard is to be launched

### DIFF
--- a/ezpublish/EzPublishKernel.php
+++ b/ezpublish/EzPublishKernel.php
@@ -23,6 +23,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle;
 use Tedivm\StashBundle\TedivmStashBundle;
 use Sensio\Bundle\DistributionBundle\SensioDistributionBundle;
+use RuntimeException;
 
 class EzPublishKernel extends Kernel
 {
@@ -68,14 +69,20 @@ class EzPublishKernel extends Kernel
      */
     public function registerContainerConfiguration( LoaderInterface $loader )
     {
-        $loader->load( __DIR__ . '/config/config_' . $this->getEnvironment() . '.yml' );
-        try
+        $environment = $this->getEnvironment();
+        $loader->load( __DIR__ . '/config/config_' . $environment . '.yml' );
+        $configFile = __DIR__ . '/config/ezpublish_' . $environment . '.yml';
+
+        if ( !is_file( $configFile ) )
         {
-            $loader->load( __DIR__ . '/config/ezpublish_' . $this->getEnvironment() . '.yml' );
+            $configFile = __DIR__ . '/config/ezpublish_setup.yml';
         }
-        catch ( \InvalidArgumentException $e )
+
+        if ( !is_readable( $configFile ) )
         {
-            $loader->load( __DIR__ . '/config/ezpublish_setup.yml' );
+            throw new RuntimeException( "Configuration file '$configFile' is not readable." );
         }
+
+        $loader->load( $configFile );
     }
 }


### PR DESCRIPTION
An InvalidArgumentException might be used inside the loader, this is not
an efficient way to know whether the setup wizard is to be launched or
not.

In case of config file corruption, the setup wizard might also be shown
since an InvalidArgumentException could be raised.
