### PR TITLE
Add dependency on ezpublish legacy, now that we have an installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
     "extra": {
         "symfony-app-dir": "ezpublish",
         "symfony-web-dir": "web",
+        "ezpublish-legacy-dir": "ezpublish_legacy",
         "branch-alias": {
             "dev-master": "5.2.x-dev"
         }


### PR DESCRIPTION
nb: prerequisite is the pull req. on ezpublish-legacy and renaming of the installer repo
