### PR TITLE
Fix EZP-21055: creating content using API causes memory leaks

### DIFF
--- a/ezpublish/config/config_dev.yml
+++ b/ezpublish/config/config_dev.yml
@@ -1,6 +1,9 @@
 imports:
     - { resource: config.yml }
 
+parameters:
+    ezpublish.spi.persistence.cache.persistenceLogger.enableCallLogging: true
+
 framework:
     router:   { resource: "%kernel.root_dir%/config/routing_dev.yml" }
     profiler: { only_exceptions: false }


### PR DESCRIPTION
Enable logging in dev mode which has been disabled by default by
the [kernel change](https://github.com/ezsystems/ezpublish-kernel/pull/397) for this issue.
