### PR TITLE
Required fix for EZP-20930: missing root REST resources

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,11 @@
         "zetacomponents/persistent-object": "@dev",
         "zetacomponents/php-generator": "@dev",
         "zetacomponents/signal-slot": "@dev",
-        "zetacomponents/system-information": "@dev"
+        "zetacomponents/system-information": "@dev",
+        "hautelook/templated-uri-bundle": "~1.0"
+    },
+    "conflict": {
+        "symfony/symfony": "2.3.9"
     },
     "require-dev": {
         "behat/behat": "2.5.*",

--- a/ezpublish/EzPublishKernel.php
+++ b/ezpublish/EzPublishKernel.php
@@ -28,6 +28,7 @@ use Sensio\Bundle\DistributionBundle\SensioDistributionBundle;
 use Tedivm\StashBundle\TedivmStashBundle;
 use WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle;
 use Nelmio\CorsBundle\NelmioCorsBundle;
+use Hautelook\TemplatedUriBundle\HautelookTemplatedUriBundle;
 
 class EzPublishKernel extends Kernel
 {
@@ -48,6 +49,7 @@ class EzPublishKernel extends Kernel
             new SwiftmailerBundle(),
             new AsseticBundle(),
             new TedivmStashBundle(),
+            new HautelookTemplatedUriBundle(),
             new EzPublishCoreBundle(),
             new EzPublishLegacyBundle(),
             new EzSystemsDemoBundle(),


### PR DESCRIPTION
See https://github.com/ezsystems/ezpublish-kernel/pull/480 & http://jira.ez.no/browse/EZP-20930.

Adds a requirement on a fork of https://github.com/hautelook/TemplatedUriBundle (see original PR for more details).
