### PR TITLE
Implement EZP-21169: As a Tester I want BDD running on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: php
+
+# run tests on php 5.4 only and let unit / integration tests deal with php differences
+php:
+  - 5.4
+
+# list of paths/bundle to execute
+env:
+  - TEST_SUIT="@eZDemoBundle"
+#  - TEST_SUIT="vendor/ezsystems/demobundle/EzSystems/DemoBundle/Features/"
+
+
+# test only master (+ Pull requests)
+branches:
+  only:
+    - master
+
+# install packages
+before_install:
+  - ./bin/.travis/behat_before_install.sh
+
+# setup requirements for running tests
+before_script:
+  - ./bin/.travis/behat_before_script1.sh
+  - ./bin/.travis/behat_before_script2.sh
+
+# execute behat as the script command
+script: "bin/behat $TEST_SUIT"
+
+# disable mail notifications
+notification:
+  email: false
+
+# reduce depth (history) of git checkout
+git:
+  depth: 30

--- a/behat.yml
+++ b/behat.yml
@@ -1,7 +1,7 @@
 default:
     extensions:
         Behat\MinkExtension\Extension:
-            base_url: 'http://ezpublish.local'
+            base_url: 'http://localhost'
             goutte: ~
             sahi: ~
 
@@ -10,5 +10,8 @@ default:
 
         Behat\Symfony2Extension\Extension:
             kernel:
+                bootstrap: ezpublish/autoload.php
                 path: ezpublish/EzPublishKernel.php
                 class: EzPublishKernel
+                env: behat
+                debug: true

--- a/bin/.travis/apache2/behat_vhost
+++ b/bin/.travis/apache2/behat_vhost
@@ -1,0 +1,58 @@
+<VirtualHost *:80>
+    ServerName localhost
+    DirectoryIndex index.php
+    DocumentRoot %basedir%/web
+
+    #LogLevel debug
+
+    SetEnv ENVIRONMENT "behat"
+    SetEnv USE_DEBUGGING 1
+    #SetEnv USE_HTTP_CACHE 1
+    #SetEnv TRUSTED_PROXIES "127.0.0.1"
+
+    <Directory %basedir%/web>
+        Options FollowSymLinks
+        AllowOverride None
+    </Directory>
+
+    <IfModule mod_rewrite.c>
+        RewriteEngine On
+
+        # CVE-2012-6432
+        RewriteRule ^/_internal - [R=403,L]
+
+        # Uncomment in FastCGI mode, to get basic auth working.
+        RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
+        RewriteCond %{REQUEST_URI} ^/php5.fastcgi(.*)
+        RewriteRule . - [L]
+
+        # v1 rest API is on Legacy
+        RewriteRule ^/api/[^/]+/v1/ /index_rest.php [L]
+
+        # If using cluster, uncomment the following two lines:
+        #RewriteRule ^/var/([^/]+/)?storage/images(-versioned)?/.* /index_cluster.php [L]
+        #RewriteRule ^/var/([^/]+/)?cache/(texttoimage|public)/.* /index_cluster.php [L]
+
+        RewriteRule ^/var/([^/]+/)?storage/images(-versioned)?/.* - [L]
+        RewriteRule ^/var/([^/]+/)?cache/(texttoimage|public)/.* - [L]
+        RewriteRule ^/design/[^/]+/(stylesheets|images|javascript|fonts)/.* - [L]
+        RewriteRule ^/share/icons/.* - [L]
+        RewriteRule ^/extension/[^/]+/design/[^/]+/(stylesheets|flash|images|lib|javascripts?)/.* - [L]
+        RewriteRule ^/packages/styles/.+/(stylesheets|images|javascript)/[^/]+/.* - [L]
+        RewriteRule ^/packages/styles/.+/thumbnail/.* - [L]
+        RewriteRule ^/var/storage/packages/.* - [L]
+
+        RewriteRule ^/favicon\.ico - [L]
+        RewriteRule ^/design/standard/images/favicon\.ico - [L]
+
+        # Following rule is needed to correctly display assets from eZ Publish5 / Symfony bundles
+        RewriteRule ^/bundles/ - [L]
+
+        # Additional Assetic rules for eZ Publish 5.1 / 2013.4 and higher:
+        RewriteRule ^/css/.*\.css - [L]
+        RewriteRule ^/js/.*\.js - [L]
+
+        RewriteRule .* /index.php
+    </IfModule>
+</VirtualHost>

--- a/bin/.travis/apache2/phpenv
+++ b/bin/.travis/apache2/phpenv
@@ -1,0 +1,14 @@
+<IfModule mod_fastcgi.c>
+        Alias /php5.fastcgi /var/lib/apache2/fastcgi/php5.fastcgi
+        AddHandler php-script .php
+        FastCGIExternalServer /var/lib/apache2/fastcgi/php5.fastcgi -socket /tmp/php-fpm.sock -idle-timeout 610
+        Action php-script /php5.fastcgi virtual
+
+        # Forbid access to the fastcgi handler.
+        <Directory /var/lib/apache2/fastcgi>
+                <Files php5.fastcgi>
+                        Order deny,allow
+                        Allow from all
+                </Files>
+        </Directory>
+</IfModule>

--- a/bin/.travis/behat_before_install.sh
+++ b/bin/.travis/behat_before_install.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Script to do tasks before install, can install system packages / software
+# See http://about.travis-ci.org/docs/user/build-configuration/
+
+wget -nv -O sahi_20130429.zip "http://downloads.sourceforge.net/project/sahi/sahi-v44/sahi_20130429.zip?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fsahi%2Ffiles%2Fsahi-v44%2F&ts=1376728867&use_mirror=garr"
+unzip -o sahi_20130429.zip -d  ~
+rm sahi_20130429.zip
+sudo chmod +x ~/sahi/bin/sahi.sh
+
+sudo apt-get update
+sudo apt-get install -q -y --force-yes apache2 libapache2-mod-fastcgi

--- a/bin/.travis/behat_before_script1.sh
+++ b/bin/.travis/behat_before_script1.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Script to do tasks before script, step 1 of 2
+## Step 1 install vendors + db + legacy + apache + sahi, but does not run scripts
+## So you can swap out a vendor for testing between step 1 and 2
+
+mysql -e "CREATE DATABASE IF NOT EXISTS behattestdb;" -uroot
+composer install --dev --prefer-dist --no-scripts
+./bin/.travis/prepare_legacy.sh
+
+# Http Server
+./bin/.travis/configure_apache2.sh
+
+# X & Sahi
+export DISPLAY=:99.0
+sh -e /etc/init.d/xvfb start
+cp -f bin/.travis/sahi/browser_types.xml-dist ~/sahi/userdata/config/browser_types.xml
+cd ~/sahi/bin
+sh -e ./sahi.sh &
+cd -
+
+# Give Sahi some time to start
+sleep 4

--- a/bin/.travis/behat_before_script2.sh
+++ b/bin/.travis/behat_before_script2.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Script to do tasks before script, step 2 of 2
+## Step 2 runs finishing scripts, you can swap out a vendor for testing
+## before this step, but if new vendor or vastly different some composer magic also needs to be done in between
+
+composer run-script --dev post-install-cmd
+php ezpublish/console --env=behat assetic:dump
+php ezpublish/console --no-interaction --env=behat ezpublish:test:init_db

--- a/bin/.travis/configure_apache2.sh
+++ b/bin/.travis/configure_apache2.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# vhost & phpenv
+sed s?%basedir%?$TRAVIS_BUILD_DIR? bin/.travis/apache2/behat_vhost | sudo tee /etc/apache2/sites-available/behat > /dev/null
+sudo cp bin/.travis/apache2/phpenv /etc/apache2/conf.d/phpconfig
+
+
+# modules enabling
+sudo a2enmod rewrite
+sudo a2enmod actions
+sudo a2enmod fastcgi
+
+# sites disabling & enabling
+sudo a2dissite default
+sudo a2ensite behat
+
+# FPM
+DIR=$(dirname "$0")
+PHP_FPM_BIN="$HOME/.phpenv/versions/$TRAVIS_PHP_VERSION/sbin/php-fpm"
+PHP_FPM_CONF="$DIR/php-fpm.conf"
+USER=$(whoami)
+
+echo "
+[global]
+
+[travis]
+user = $USER
+group = $USER
+listen = /tmp/php-fpm.sock
+pm = static
+pm.max_children = 2
+
+php_admin_value[memory_limit] = 128M
+" > $PHP_FPM_CONF
+
+# restart
+sudo $PHP_FPM_BIN --fpm-config "$PHP_FPM_CONF"
+sudo service apache2 restart

--- a/bin/.travis/ezrouter.php
+++ b/bin/.travis/ezrouter.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+putenv("ENVIRONMENT=behat");
+require __DIR__ . "/../ezrouter.php";

--- a/bin/.travis/prepare_legacy.sh
+++ b/bin/.travis/prepare_legacy.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+
+if [ -d ezpublish_legacy ]; then
+    echo "Legacy folder exists already, KTHXBYE"
+    exit 1
+fi
+
+# Get eZ Publish Legacy
+git clone --depth 1 https://github.com/ezsystems/ezpublish-legacy.git ezpublish_legacy
+
+# Get package extensions
+mkdir ezpublish_legacy_packages
+cd ezpublish_legacy_packages
+git clone --depth 1 https://github.com/ezsystems/ezdemo.git
+git clone --depth 1 https://github.com/ezsystems/ezflow.git
+git clone --depth 1 https://github.com/ezsystems/ezgmaplocation.git
+git clone --depth 1 https://github.com/ezsystems/ezstarrating.git
+git clone --depth 1 https://github.com/ezsystems/ezwt.git
+#git clone --depth 1 https://github.com/ezsystems/ezcomments.git
+
+
+# Symlink extensions
+cd ../ezpublish_legacy/extension
+ln -s ../../ezpublish_legacy_packages/ezdemo/packages/ezdemo_extension/ezextension/ezdemo
+ln -s ../../ezpublish_legacy_packages/ezflow/packages/ezflow_extension/ezextension/ezflow
+ln -s ../../ezpublish_legacy_packages/ezgmaplocation/packages/ezgmaplocation_extension/ezextension/ezgmaplocation
+ln -s ../../ezpublish_legacy_packages/ezstarrating/packages/ezstarrating_extension/ezextension/ezstarrating
+ln -s ../../ezpublish_legacy_packages/ezwt/packages/ezwt_extension/ezextension/ezwt
+#ln -s ../../ezpublish_legacy_packages/ezcomments/packages/ezcomments_extension/ezextension/ezcomments
+
+cd ..
+
+# Fix folder permissions
+./bin/modfix.sh
+
+# Generate extensions autoload
+php bin/php/ezpgenerateautoloads.php -e
+
+# Create settings
+mkdir settings/override
+mkdir settings/siteaccess/behat_site
+mkdir settings/siteaccess/behat_site_admin
+
+
+echo "[SiteAccessSettings]
+CheckValidity=false
+RelatedSiteAccessList[]
+RelatedSiteAccessList[]=behat_site
+RelatedSiteAccessList[]=behat_site_admin
+
+[SiteSettings]
+SiteName=eZ Publish Behat Test Site
+SiteURL=localhost
+
+[Session]
+SessionNameHandler=custom
+SessionNamePerSiteAccess=disabled
+
+[DebugSettings]
+DebugRedirection=disabled
+
+[ExtensionSettings]
+ActiveExtensions[]=ezjscore
+ActiveExtensions[]=ezoe
+ActiveExtensions[]=ezformtoken
+ActiveExtensions[]=ezdemo
+ActiveExtensions[]=ezflow
+ActiveExtensions[]=ezwt
+ActiveExtensions[]=ezgmaplocation
+ActiveExtensions[]=ezstarrating
+#ActiveExtensions[]=ezcomments" > settings/override/site.ini
+
+
+echo "[SiteAccessSettings]
+RequireUserLogin=false
+ShowHiddenNodes=false
+
+[DesignSettings]
+SiteDesign=ezdemo
+AdditionalSiteDesignList[]
+AdditionalSiteDesignList[]=ezflow
+AdditionalSiteDesignList[]=base
+
+[SiteSettings]
+LoginPage=embedded" > settings/siteaccess/behat_site/site.ini
+
+echo "[SiteSettings]
+DefaultPage=content/dashboard
+
+[SiteAccessSettings]
+RequireUserLogin=true
+ShowHiddenNodes=true
+
+[DesignSettings]
+SiteDesign=admin2
+AdditionalSiteDesignList[]
+AdditionalSiteDesignList[]=admin
+AdditionalSiteDesignList[]=ezdemo" > settings/siteaccess/behat_site_admin/site.ini
+
+

--- a/bin/.travis/sahi/browser_types.xml-dist
+++ b/bin/.travis/sahi/browser_types.xml-dist
@@ -1,0 +1,11 @@
+<browserTypes>
+	<browserType>
+		<name>firefox</name>
+		<displayName>Firefox</displayName>
+		<icon>firefox.png</icon>
+		<path>/usr/local/bin/firefox</path>
+		<options>-profile "$userDir/browser/ff/profiles/sahi$threadNo" -no-remote</options>
+		<processName>firefox</processName>
+		<capacity>5</capacity>
+	</browserType>
+</browserTypes>

--- a/bin/ezrouter.php
+++ b/bin/ezrouter.php
@@ -32,8 +32,11 @@ EOT;
     exit;
 }
 
-// Use indev_dev.php front controller to have all debug tools and info.
-$script = 'index_dev.php';
+// Use indev_dev.php front controller to have all debug tools and info unless ENVIRONMENT is set.
+if ( getenv( "ENVIRONMENT" ) === false )
+    $script = 'index_dev.php';
+else
+    $script = 'index.php';
 
 // To stick with regular Apache HTTPD behaviour, SCRIPT_NAME should equal to PHP_SELF.
 // Fix SCRIPT_NAME and PHP_SELF since we deal with virtual folders, so PHP server would append /index.php to it.

--- a/composer.lock
+++ b/composer.lock
@@ -726,16 +726,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/AsseticBundle.git",
-                "reference": "146dd3cb46b302bd471560471c6aaa930483dac1"
+                "reference": "v2.3.0-beta1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/AsseticBundle/zipball/146dd3cb46b302bd471560471c6aaa930483dac1",
-                "reference": "146dd3cb46b302bd471560471c6aaa930483dac1",
+                "url": "https://api.github.com/repos/symfony/AsseticBundle/zipball/v2.3.0-beta1",
+                "reference": "v2.3.0-beta1",
                 "shasum": ""
             },
             "require": {
-                "kriswallsmith/assetic": "~1.1",
+                "kriswallsmith/assetic": ">=1.1-beta1,<1.2",
                 "php": ">=5.3.0",
                 "symfony/framework-bundle": "~2.1"
             },
@@ -780,7 +780,7 @@
                 "compression",
                 "minification"
             ],
-            "time": "2013-05-16 05:32:23"
+            "time": "2013-05-13 15:39:47"
         },
         {
             "name": "symfony/icu",
@@ -3201,12 +3201,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/fabpot/Goutte.git",
-                "reference": "75c9f23c4122caf4ea3e87a42a00b471366e707f"
+                "reference": "v1.0.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fabpot/Goutte/zipball/75c9f23c4122caf4ea3e87a42a00b471366e707f",
-                "reference": "75c9f23c4122caf4ea3e87a42a00b471366e707f",
+                "url": "https://api.github.com/repos/fabpot/Goutte/zipball/v1.0.3",
+                "reference": "v1.0.3",
                 "shasum": ""
             },
             "require": {
@@ -3258,12 +3258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/common.git",
-                "reference": "70c8e8a624e2ef1657ce0045d845bee9f46a325e"
+                "reference": "v3.7.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/common/zipball/70c8e8a624e2ef1657ce0045d845bee9f46a325e",
-                "reference": "70c8e8a624e2ef1657ce0045d845bee9f46a325e",
+                "url": "https://api.github.com/repos/guzzle/common/zipball/v3.7.2",
+                "reference": "v3.7.2",
                 "shasum": ""
             },
             "require": {
@@ -3302,12 +3302,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/http.git",
-                "reference": "a18954489d8af2e04ee9e3bafd3bf703b55459ff"
+                "reference": "v3.7.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/http/zipball/a18954489d8af2e04ee9e3bafd3bf703b55459ff",
-                "reference": "a18954489d8af2e04ee9e3bafd3bf703b55459ff",
+                "url": "https://api.github.com/repos/guzzle/http/zipball/v3.7.2",
+                "reference": "v3.7.2",
                 "shasum": ""
             },
             "require": {
@@ -3359,12 +3359,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/parser.git",
-                "reference": "a25c2ddda1c52fb69a4ee56eb530b13ddd9573c2"
+                "reference": "v3.7.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/parser/zipball/a25c2ddda1c52fb69a4ee56eb530b13ddd9573c2",
-                "reference": "a25c2ddda1c52fb69a4ee56eb530b13ddd9573c2",
+                "url": "https://api.github.com/repos/guzzle/parser/zipball/v3.7.2",
+                "reference": "v3.7.2",
                 "shasum": ""
             },
             "require": {
@@ -3403,12 +3403,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/stream.git",
-                "reference": "a86111d9ac7db31d65a053c825869409fe8fc83f"
+                "reference": "v3.7.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/stream/zipball/a86111d9ac7db31d65a053c825869409fe8fc83f",
-                "reference": "a86111d9ac7db31d65a053c825869409fe8fc83f",
+                "url": "https://api.github.com/repos/guzzle/stream/zipball/v3.7.2",
+                "reference": "v3.7.2",
                 "shasum": ""
             },
             "require": {
@@ -3699,12 +3699,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "af7b77ccb5c64458bdfca95665d29558d1df7d08"
+                "reference": "3.7.24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/af7b77ccb5c64458bdfca95665d29558d1df7d08",
-                "reference": "af7b77ccb5c64458bdfca95665d29558d1df7d08",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3.7.24",
+                "reference": "3.7.24",
                 "shasum": ""
             },
             "require": {

--- a/ezpublish/EzPublishKernel.php
+++ b/ezpublish/EzPublishKernel.php
@@ -54,6 +54,7 @@ class EzPublishKernel extends Kernel
         switch ( $this->getEnvironment() )
         {
             case "test":
+            case "behat":
                 $bundles[] = new EzSystemsEzPublishBehatBundle();
                 // No break, test also needs dev bundles
             case "dev":

--- a/ezpublish/config/config_behat.yml
+++ b/ezpublish/config/config_behat.yml
@@ -1,0 +1,11 @@
+imports:
+    - { resource: config_dev.yml }
+
+framework:
+    test: ~
+    profiler:
+        enabled: false
+
+web_profiler:
+    toolbar: false
+    intercept_redirects: false

--- a/ezpublish/config/ezpublish_behat.yml
+++ b/ezpublish/config/ezpublish_behat.yml
@@ -1,0 +1,35 @@
+ezpublish:
+    siteaccess:
+        # Available siteaccesses
+        list:
+            - behat_site
+            - behat_site_admin
+        # Siteaccess groups. Use them to group common settings.
+        groups:
+            behat_group: [behat_site, behat_site_admin]
+        default_siteaccess: behat_site
+        match:
+            Map\URI:
+                behat_site_admin: behat_site_admin
+            Map\Host:
+                localhost: behat_site
+    system:
+        behat_group:
+            database:
+                type: mysql
+                user: root
+                server: localhost
+                database_name: behattestdb
+            languages: [eng-GB]
+            var_dir: var/behat_site
+        behat_site:
+            legacy_mode: false
+        behat_site_admin:
+            legacy_mode: true
+
+stash:
+    caches:
+        default:
+            handlers: [ FileSystem ]
+            inMemory: true
+            registerDoctrineAdapter: false


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-21169

This approach is using mysql, I attempted using sqlite first but since legacy is needed it can not work without making a new sql driver for legacy which is out of the scope of this story.

For review & testing, remaining tasks:
- [x] Support for self installing ez Publish based on fixtures ( ezsystems/ezpublish-kernel#486 )
- [x] Travis config and adjustmenst for behat test runs
- [x] New fixture dump based on more recent clean install of ezdemo with all tables so it might work on legacy (as needed by DemoBundle at the moment)
- [ ] Full ezpublish schema for mysql, postgres and sqlite so data dump can be reused for integration tests as well 
- [x] Merge https://github.com/ezsystems/ezpublish-kernel/pull/486
- [x] Enable Travis hook
- [x] Run composer update on this branch and push to trigger first test run
- [x] Get Sahi running somehow for javascript tests (pr preferably casperJS if Mink driver exists)
- [x] Add Demo Bundle tests that actually test javascript and login functionality
