### PR TITLE
EZP-21420: Added zetacomponents/event-log to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "zetacomponents/console-tools": "@dev",
         "zetacomponents/database": "@dev",
         "zetacomponents/debug": "@dev",
+        "zetacomponents/event-log": "@dev",
         "zetacomponents/feed": "@dev",
         "zetacomponents/image-conversion": "@dev",
         "zetacomponents/mail": "@dev",


### PR DESCRIPTION
This is a follow-up to https://github.com/ezsystems/ezpublish-legacy/pull/717 which adds zetacomponents/event-log to the `composer.json` file.

Also, the `composer.lock` file is removed from git as it is automatically generated when performing a `composer install/update`.
