### PR TITLE
Add a Browser layer for BDD tests

### DIFF
--- a/src/EzSystems/BehatBundle/Features/Context/BrowserContext.php
+++ b/src/EzSystems/BehatBundle/Features/Context/BrowserContext.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * File containing the BrowserContext class.
+ *
+ * This class contains general feature context for Behat.
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace EzSystems\BehatBundle\Features\Context;
+
+use EzSystems\BehatBundle\Features\Context\FeatureContext as BaseFeatureContext;
+use PHPUnit_Framework_Assert as Assertion;
+use Behat\Behat\Context\Step;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Behat\Exception\PendingException;
+use Behat\Mink\Exception\UnsupportedDriverActionException as MinkUnsupportedDriverActionException;
+
+/**
+ * Browser interface helper context.
+ */
+class BrowserContext extends BaseFeatureContext
+{
+    /**
+     * @Given /^(?:|I )am logged in as "([^"]*)" with password "([^"]*)"$/
+     */
+    public function iAmLoggedInAsWithPassword( $user, $password )
+    {
+        return array(
+            new Step\Given( 'I am on "/user/login"' ),
+            new Step\When( 'I fill in "Username" with "' . $user . '"' ),
+            new Step\When( 'I fill in "Password" with "' . $password . '"' ),
+            new Step\When( 'I press "Login"' ),
+            new Step\Then( 'I should be redirected to "/"' ),
+        );
+    }
+
+    /**
+     * @Then /^(?:|I )am (?:at|on) the "([^"]*)(?:| page)"$/
+     */
+    public function iAmOnThe( $pageIdentifier )
+    {
+        $currentUrl = $this->getUrlWithoutQueryString( $this->getSession()->getCurrentUrl() );
+
+        $expectedUrl = $this->locatePath( $this->getPathByPageIdentifier( $pageIdentifier ) );
+
+        Assertion::assertEquals(
+            $expectedUrl,
+            $currentUrl,
+            "Unexpected URL of the current site. Expected: '$expectedUrl'. Actual: '$currentUrl'."
+        );
+    }
+
+    /**
+     * @Given /^(?:|I )am (?:at|on) (?:|the )"([^"]*)" page$/
+     * @When  /^(?:|I )go to (?:|the )"([^"]*)"(?:| page)$/
+     */
+    public function iGoToThe( $pageIdentifier )
+    {
+        return array(
+            new Step\When( 'I am on "' . $this->getPathByPageIdentifier( $pageIdentifier ) . '"' ),
+        );
+    }
+
+    /**
+     * @When /^(?:|I )search for "([^"]*)"$/
+     */
+    public function iSearchFor( $searchPhrase )
+    {
+        $session = $this->getSession();
+        $searchField = $session->getPage()->findById( 'site-wide-search-field' );
+
+        Assertion::assertNotNull( $searchField, 'Search field not found.' );
+
+        $searchField->setValue( $searchPhrase );
+
+        // Ideally, using keyPress(), but doesn't work since no keypress handler exists
+        // http://sahi.co.in/forums/discussion/2717/keypress-in-java/p1
+        //     $searchField->keyPress( 13 );
+        //
+        // Using JS instead:
+        // Note:
+        //     $session->executeScript( "$('#site-wide-search').submit();" );
+        // Gives:
+        //     error:_call($('#site-wide-search').submit();)
+        //     SyntaxError: missing ) after argument list
+        //     Sahi.ex@http://<hostname>/_s_/spr/concat.js:3480
+        //     @http://<hostname>/_s_/spr/concat.js:3267
+        // Solution: Encapsulating code in a closure.
+        // @todo submit support where recently added to MinkCoreDriver, should us it when the drivers we use support it
+        try
+        {
+            $session->executeScript( "(function(){ $('#site-wide-search').submit(); })()" );
+        }
+        catch ( MinkUnsupportedDriverActionException $e )
+        {
+            // For drivers not able to do javascript we assume we can click the hidden button
+            $searchField->getParent()->findButton( 'SearchButton' )->click();
+        }
+
+        // Store for reuse in result page
+        $this->priorSearchPhrase = $searchPhrase;
+    }
+
+    /**
+     * @Given /^(?:|I )see search (\d+) result$/
+     */
+    public function iSeeSearchResults( $arg1 )
+    {
+        $resultCountElement = $this->getSession()->getPage()->find( 'css', 'div.feedback' );
+
+        Assertion::assertNotNull(
+            $resultCountElement,
+            'Could not find result count text element.'
+        );
+
+        Assertion::assertEquals(
+            "Search for \"{$this->priorSearchPhrase}\" returned {$arg1} matches",
+            $resultCountElement->getText()
+        );
+    }
+
+    /**
+     * @Then /^(?:|I )see (\d+) "([^"]*)" elements listed$/
+     */
+    public function iSeeListedElements( $count, $objectType )
+    {
+        $objectListTable = $this->getSession()->getPage()->find(
+            'xpath',
+            '//table[../h1 = "' . $objectType  . ' list"]'
+        );
+
+        Assertion::assertNotNull(
+            $objectListTable,
+            'Could not find listing table for ' . $objectType
+        );
+
+        Assertion::assertCount(
+            $count + 1,
+            $objectListTable->findAll( 'css', 'tr' ),
+            'Found incorrect number of table rows.'
+        );
+    }
+
+    /**
+     * @Then /^(?:|I )should be redirected to "([^"]*)"$/
+     */
+    public function iShouldBeRedirectedTo( $redirectTarget )
+    {
+        $redirectForm = $this->getSession()->getPage()->find( 'css', 'form[name="Redirect"]' );
+
+        Assertion::assertNotNull(
+            $redirectForm,
+            'Missing redirect form.'
+        );
+
+        Assertion::assertEquals( $redirectTarget, $redirectForm->getAttribute( 'action' ) );
+    }
+
+    /**
+     * @Then /^(?:|I )want dump of (?:|the )page$/
+     */
+    public function iWantDumpOfThePage()
+    {
+        echo $this->getSession()->getPage()->getContent();
+    }
+}

--- a/src/EzSystems/BehatBundle/Features/Context/FeatureContext.php
+++ b/src/EzSystems/BehatBundle/Features/Context/FeatureContext.php
@@ -11,15 +11,12 @@
 
 namespace EzSystems\BehatBundle\Features\Context;
 
-use Behat\Behat\Context\Step;
 use Behat\Behat\Event\OutlineExampleEvent;
 use Behat\Behat\Event\ScenarioEvent;
 use Behat\MinkExtension\Context\MinkContext;
-use Behat\Mink\Exception\UnsupportedDriverActionException as MinkUnsupportedDriverActionException;
 use Behat\Symfony2Extension\Context\KernelAwareInterface;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use PHPUnit_Framework_Assert as Assertion;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
@@ -98,80 +95,6 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
     }
 
     /**
-     * @When /^I search for "([^"]*)"$/
-     */
-    public function iSearchFor( $searchPhrase )
-    {
-        $session = $this->getSession();
-        $searchField = $session->getPage()->findById( 'site-wide-search-field' );
-
-        Assertion::assertNotNull( $searchField, 'Search field not found.' );
-
-        $searchField->setValue( $searchPhrase );
-
-        // Ideally, using keyPress(), but doesn't work since no keypress handler exists
-        // http://sahi.co.in/forums/discussion/2717/keypress-in-java/p1
-        //     $searchField->keyPress( 13 );
-        //
-        // Using JS instead:
-        // Note:
-        //     $session->executeScript( "$('#site-wide-search').submit();" );
-        // Gives:
-        //     error:_call($('#site-wide-search').submit();)
-        //     SyntaxError: missing ) after argument list
-        //     Sahi.ex@http://<hostname>/_s_/spr/concat.js:3480
-        //     @http://<hostname>/_s_/spr/concat.js:3267
-        // Solution: Encapsulating code in a closure.
-        // @todo submit support where recently added to MinkCoreDriver, should us it when the drivers we use support it
-        try
-        {
-            $session->executeScript( "(function(){ $('#site-wide-search').submit(); })()" );
-        }
-        catch ( MinkUnsupportedDriverActionException $e )
-        {
-            // For drivers not able to do javascript we assume we can click the hidden button
-            $searchField->getParent()->findButton( 'SearchButton' )->click();
-        }
-
-        // Store for reuse in result page
-        $this->priorSearchPhrase = $searchPhrase;
-    }
-
-    /**
-     * @Then /^I am on the "([^"]*)"$/
-     */
-    public function iAmOnThe( $pageIdentifier )
-    {
-        $currentUrl = $this->getUrlWithoutQueryString( $this->getSession()->getCurrentUrl() );
-
-        $expectedUrl = $this->locatePath( $this->getPathByPageIdentifier( $pageIdentifier ) );
-
-        Assertion::assertEquals(
-            $expectedUrl,
-            $currentUrl,
-            "Unexpected URL of the current site. Expected: '$expectedUrl'. Actual: '$currentUrl'."
-        );
-    }
-
-    /**
-     * @Then /^(?:|I )want dump of (?:|the )page$/
-     */
-    public function iWantDumpOfThePage()
-    {
-        echo $this->getSession()->getPage()->getContent();
-    }
-
-    /**
-     * @When /^I go to the "([^"]*)"$/
-     */
-    public function iGoToThe( $pageIdentifier )
-    {
-        return array(
-            new Step\When( 'I am on "' . $this->getPathByPageIdentifier( $pageIdentifier ) . '"' ),
-        );
-    }
-
-    /**
      * Returns the path associated with $pageIdentifier
      *
      * @param string $pageIdentifier
@@ -203,74 +126,5 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
         }
 
         return $url;
-    }
-
-    /**
-     * @Given /^I see search (\d+) result$/
-     */
-    public function iSeeSearchResults( $arg1 )
-    {
-        $resultCountElement = $this->getSession()->getPage()->find( 'css', 'div.feedback' );
-
-        Assertion::assertNotNull(
-            $resultCountElement,
-            'Could not find result count text element.'
-        );
-
-        Assertion::assertEquals(
-            "Search for \"{$this->priorSearchPhrase}\" returned {$arg1} matches",
-            $resultCountElement->getText()
-        );
-    }
-
-    /**
-     * @Given /^I am logged in as "([^"]*)" with password "([^"]*)"$/
-     */
-    public function iAmLoggedInAsWithPassword( $user, $password )
-    {
-        return array(
-            new Step\Given( 'I am on "/user/login"' ),
-            new Step\When( 'I fill in "Username" with "' . $user . '"' ),
-            new Step\When( 'I fill in "Password" with "' . $password . '"' ),
-            new Step\When( 'I press "Login"' ),
-            new Step\Then( 'I should be redirected to "/"' ),
-        );
-    }
-
-    /**
-     * @Then /^I should be redirected to "([^"]*)"$/
-     */
-    public function iShouldBeRedirectedTo( $redirectTarget )
-    {
-        $redirectForm = $this->getSession()->getPage()->find( 'css', 'form[name="Redirect"]' );
-
-        Assertion::assertNotNull(
-            $redirectForm,
-            'Missing redirect form.'
-        );
-
-        Assertion::assertEquals( $redirectTarget, $redirectForm->getAttribute( 'action' ) );
-    }
-
-    /**
-     * @Then /^I see (\d+) "([^"]*)" elements listed$/
-     */
-    public function iSeeListedElements( $count, $objectType )
-    {
-        $objectListTable = $this->getSession()->getPage()->find(
-            'xpath',
-            '//table[../h1 = "' . $objectType  . ' list"]'
-        );
-
-        Assertion::assertNotNull(
-            $objectListTable,
-            'Could not find listing table for ' . $objectType
-        );
-
-        Assertion::assertCount(
-            $count + 1,
-            $objectListTable->findAll( 'css', 'tr' ),
-            'Found incorrect number of table rows.'
-        );
     }
 }


### PR DESCRIPTION
Adding a Browser layer between FeatureContext of BehatBundle and DemoBundle will make possible to:
- have all code generic for any API (PAPI, REST, or Browser Interfaces)
- all generic browser actions on BrowserContext

Behat has a known limitation that is the RegEx must be unique, can only exist once, so if we got a sentence like:
- "Then I see search 1 result" 

so for a browser interface such as DemoBundle the code for asserting total search results is different form PAPI or REST. and this being implemented on BehatBundle FeatureContext would make impossible to redefine this for the others API's.
Also defining this on DemoBundle FeatureContext wouldn't be a pleasant option, since to test other browser interfaces the code needed to be copy pasted to all other interfaces duplicating the code and with it bringing all the code maintenance problems.

There will be a PR's also for DemoBundle changing the inheritance of the FeatureContext, I'll post here the link as soon as it is done.

Edit: 
DemoBundle PR: https://github.com/ezsystems/DemoBundle/pull/26
