### PR TITLE
EZP-21633: [Behat] Fix siteaccess injection which fails in some cases

### DIFF
--- a/src/EzSystems/BehatBundle/Features/Context/FeatureContext.php
+++ b/src/EzSystems/BehatBundle/Features/Context/FeatureContext.php
@@ -17,6 +17,7 @@ use Behat\Mink\Exception\UnsupportedDriverActionException as MinkUnsupportedDriv
 use Behat\Symfony2Extension\Context\KernelAwareInterface;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use PHPUnit_Framework_Assert as Assertion;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
@@ -65,7 +66,12 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
     public function setKernel( KernelInterface $kernel )
     {
         $this->kernel = $kernel;
-        $this->kernel->getContainer()->set( 'ezpublish.siteaccess', $this->generateSiteAccess() );
+        $container = $this->kernel->getContainer();
+        // Inject a properly generated siteaccess if the kernel is booted, and thus container is available.
+        if ( $container instanceof ContainerInterface )
+        {
+            $container->set( 'ezpublish.siteaccess', $this->generateSiteAccess() );
+        }
     }
 
     /**


### PR DESCRIPTION
In some cases kernel is not yet booted so container is not avaiable, which leads to a fatal error.
This PR solves this.
