### PR TITLE
Skip bootstrap.php.cache/classes cache in debug mode

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -11,7 +11,21 @@ if ( $environment === false )
     $environment = "prod";
 }
 
-$loader = require_once __DIR__ . '/../ezpublish/bootstrap.php.cache';
+// Depending on the USE_DEBUGGING environment variable, tells whether Symfony should be loaded with debugging.
+// If not set it is activated if in "dev" environment.
+if ( ( $useDebugging = getenv( "USE_DEBUGGING" ) ) === false )
+{
+    $useDebugging = $environment === "dev";
+}
+
+if ( $useDebugging )
+{
+    $loader = require_once __DIR__ . '/../ezpublish/autoload.php';
+}
+else
+{
+    $loader = require_once __DIR__ . '/../ezpublish/bootstrap.php.cache';
+}
 
 // Depending on the USE_APC_CLASSLOADER environment variable, use APC for autoloading to improve performance.
 // If not set it is not used.
@@ -24,21 +38,19 @@ if ( getenv( "USE_APC_CLASSLOADER" ) )
 }
 
 require_once __DIR__ . '/../ezpublish/EzPublishKernel.php';
-require_once __DIR__ . '/../ezpublish/EzPublishCache.php';
 
-// Depending on the USE_DEBUGGING environment variable, tells whether Symfony should be loaded with debugging.
-// If not set it is activated if in "dev" environment.
-if ( ( $useDebugging = getenv( "USE_DEBUGGING" ) ) === false )
-{
-    $useDebugging = $environment === "dev";
-}
 if ( $useDebugging )
 {
     Debug::enable();
 }
 
 $kernel = new EzPublishKernel( $environment, $useDebugging );
-$kernel->loadClassCache();
+
+// we don't want to use the classes cache if we are in a debug session
+if ( !$useDebugging )
+{
+    $kernel->loadClassCache();
+}
 
 // Depending on the USE_HTTP_CACHE environment variable, tells whether the internal HTTP Cache mechanism is to be used.
 // If not set it is activated if not in "dev" environment.
@@ -49,6 +61,7 @@ if ( ( $useHttpCache = getenv( "USE_HTTP_CACHE" ) ) === false )
 // Load HTTP Cache ...
 if ( $useHttpCache )
 {
+    require_once __DIR__ . '/../ezpublish/EzPublishCache.php';
     $kernel = new EzPublishCache( $kernel );
 }
 


### PR DESCRIPTION
> http://jira.ez.no/browse/https://jira.ez.no/browse/EZP-22590

`bootstrap.php.cache` and classes cache can really get in the way with interactive debugging sessions.

This changes the front controller so that when debugging, if the \ XDEBUG_SESSION` cookie is set, the cache files above won't be loaded, so that the actual, original files can be stepped through.
### Points to sort out
- [x] What about other debugging methods / extensions ? Different cookie ? _We skip cache in debug mode, no debugger condition_
- [x] Does it cover all scenarios (command line / web). _Yep, no conditions on cookie._
- [x] Create story, if acceptable
