### PR TITLE
EZP-22139: require nelmio/cors-bundle @dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "ezsystems/comments-bundle": "@dev",
         "egulias/listeners-debug-command-bundle": "1.6.*",
         "white-october/pagerfanta-bundle": "1.0.*",
-        "nelmio/cors-bundle": "dev-abstract_cors_configuration",
+        "nelmio/cors-bundle": "@dev",
         "zetacomponents/archive": "@dev",
         "zetacomponents/authentication": "@dev",
         "zetacomponents/authentication-database-tiein": "@dev",
@@ -98,11 +98,5 @@
         "branch-alias": {
             "dev-master": "5.3.x-dev"
         }
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/bdunogier/NelmioCorsBundle"
-        }
-    ]
+    }
 }


### PR DESCRIPTION
Since nelmio/NelmioCorsBundle#16 has been merged to master, bumping the requirement so that QA can test the merged version before it gets tagged.
