### PR TITLE
Fix EZP-22225 - Creating a custom symfony command is returning error

### DIFF
--- a/ezpublish/EzPublishKernel.php
+++ b/ezpublish/EzPublishKernel.php
@@ -100,4 +100,18 @@ class EzPublishKernel extends Kernel
 
         $loader->load( $configFile );
     }
+
+    /**
+     * Initializes the Container
+     */
+    protected function initializeContainer()
+    {
+        parent::initializeContainer();
+        if ( PHP_SAPI == 'cli' ) 
+        {
+            $this->getContainer()->enterScope( 'request' );
+            $this->getContainer()->set( 'request', new \Symfony\Component\HttpFoundation\Request(), 'request' );
+        }
+    }
+
 }


### PR DESCRIPTION
## EZP-22225 - Creating a custom symfony command is returning error

https://jira.ez.no/browse/EZP-22225

Creating a custom console command is returning the following error:

```
  [Symfony\Component\DependencyInjection\Exception\InactiveScopeException]   
  You cannot create a service ("request") of an inactive scope ("request").
```

Steps:
Created a new bundle "php ezpublish/console generate:bundle"
Inside this bundle created a command that uses public API
Run the command with "php ezpublish/console <command>"
