### PR TITLE
EZP-22152: Add templates to the web debug toolbar

### DIFF
--- a/ezpublish/EzPublishKernel.php
+++ b/ezpublish/EzPublishKernel.php
@@ -9,6 +9,7 @@
 
 use Egulias\ListenersDebugCommandBundle\EguliasListenersDebugCommandBundle;
 use eZ\Bundle\EzPublishCoreBundle\EzPublishCoreBundle;
+use eZ\Bundle\EzPublishDebugBundle\EzPublishDebugBundle;
 use eZ\Bundle\EzPublishLegacyBundle\EzPublishLegacyBundle;
 use eZ\Bundle\EzPublishRestBundle\EzPublishRestBundle;
 use EzSystems\CommentsBundle\EzSystemsCommentsBundle;
@@ -66,6 +67,7 @@ class EzPublishKernel extends Kernel
                 $bundles[] = new EzSystemsEzPublishBehatBundle();
                 // No break, test also needs dev bundles
             case "dev":
+                $bundles[] = new EzPublishDebugBundle();
                 $bundles[] = new WebProfilerBundle();
                 $bundles[] = new SensioDistributionBundle();
                 $bundles[] = new SensioGeneratorBundle();


### PR DESCRIPTION
**BEFORE MERGING, revert https://github.com/ezsystems/ezpublish-community/commit/96b20f26b2fbf4c0a9d592a152e5e8a04fd49338**

ezpublish-community changes for http://jira.ez.no/browse/EZP-22152 (https://github.com/ezsystems/ezpublish-kernel/pull/695) .

Adds the newly introduced `EzPublishDebugBundle` to the list of loaded bundles in dev env.
