### PR TITLE
Fix EZP-22257 - BDD: PHP Warning: preg_match(): No ending delimiter '/' found in

### DIFF
--- a/src/EzSystems/BehatBundle/Features/Context/BrowserContext.php
+++ b/src/EzSystems/BehatBundle/Features/Context/BrowserContext.php
@@ -237,7 +237,7 @@ class BrowserContext extends BaseFeatureContext
     }
 
     /**
-     * @Then /^I (?:don\'t|do not) see (?:a |)"([^"]*)" link$
+     * @Then /^I (?:don\'t|do not) see (?:a |)"([^"]*)" link$/
      */
     public function iDontSeeALink( $link )
     {


### PR DESCRIPTION
# Fix EZP-22257 - BDD: PHP Warning: preg_match(): No ending delimiter '/' found in

https://jira.ez.no/browse/EZP-22257
