### PR TITLE
EZP-22151: Refactor Legacy SE to use Doctrine DBAL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "zetacomponents/php-generator": "@dev",
         "zetacomponents/signal-slot": "@dev",
         "zetacomponents/system-information": "@dev",
-        "hautelook/templated-uri-bundle": "~1.0"
+        "hautelook/templated-uri-bundle": "~1.0",
+        "doctrine/dbal": "~2.4"
     },
     "conflict": {
         "symfony/symfony": "2.3.9"


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-22151

Adds Doctrine DBAL dependency, needed by https://github.com/ezsystems/ezpublish-kernel/pull/704
