### PR TITLE
EZP-22110: Loads DemoBundle routing.yml

### DIFF
--- a/ezpublish/config/routing.yml
+++ b/ezpublish/config/routing.yml
@@ -20,3 +20,6 @@ _ezpublishRestOptionsRoutes:
     resource: "@EzPublishRestBundle/Resources/config/routing.yml"
     prefix: %ezpublish_rest.path_prefix%
     type: rest_options
+
+_ezpublishDemoRoutes:
+    resource: "@eZDemoBundle/Resources/config/routing.yml"


### PR DESCRIPTION
## Description

In order to demo ajax requests in the DemoBundle we need to be able to add custom routes.
## Tests

Added custom routes inside DemoBundle.

Link to the issue where we need ajax calls: https://jira.ez.no/browse/EZP-22110
