### PR TITLE
Travis: remove AcceptPathInfo to reflect documentation

### DIFF
--- a/bin/.travis/apache2/behat_vhost
+++ b/bin/.travis/apache2/behat_vhost
@@ -2,7 +2,6 @@
     ServerName localhost
     DirectoryIndex index.php
     DocumentRoot %basedir%/web
-    AcceptPathInfo On
 
     #LogLevel debug
 


### PR DESCRIPTION
Removing path info from the virtual host to reflect the documentation.
