### PR TITLE
EZP-22128: Centeralize Copyright & License info

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,7 @@
+Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+This source code is provided under the following license:
+
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 

--- a/bin/.travis/ezrouter.php
+++ b/bin/.travis/ezrouter.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
- * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
 

--- a/bin/ezrouter.php
+++ b/bin/ezrouter.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
- * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
 

--- a/ezpublish/EzPublishCache.php
+++ b/ezpublish/EzPublishCache.php
@@ -2,8 +2,8 @@
 /**
  * File containing the EzPublishCache class.
  *
- * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
- * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
 

--- a/ezpublish/EzPublishKernel.php
+++ b/ezpublish/EzPublishKernel.php
@@ -2,8 +2,8 @@
 /**
  * File containing the EzPublishKernel class.
  *
- * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
- * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
 

--- a/ezpublish/autoload.php
+++ b/ezpublish/autoload.php
@@ -3,8 +3,8 @@
  * File containing the autoload configuration.
  * It uses Composer autoloader and is greatly inspired by the Symfony standard distribution's.
  *
- * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
- * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
 

--- a/src/EzSystems/BehatBundle/EzSystemsBehatBundle.php
+++ b/src/EzSystems/BehatBundle/EzSystemsBehatBundle.php
@@ -2,8 +2,8 @@
 /**
  * File containing the EzSystemsEzPublishBehatBundle class.
  *
- * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
- * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
 

--- a/src/EzSystems/BehatBundle/Features/Context/Browser/BrowserContext.php
+++ b/src/EzSystems/BehatBundle/Features/Context/Browser/BrowserContext.php
@@ -4,8 +4,8 @@
  *
  * This class contains general feature context for Behat.
  *
- * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
- * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
 

--- a/src/EzSystems/BehatBundle/Features/Context/Browser/BrowserInternalSentences.php
+++ b/src/EzSystems/BehatBundle/Features/Context/Browser/BrowserInternalSentences.php
@@ -5,8 +5,8 @@
  * This interface contains the browser internal sentences that will match some
  * action or assertion for browser testing
  *
- * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
- * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
 

--- a/src/EzSystems/BehatBundle/Features/Context/Browser/SubContexts/AuthenticationContext.php
+++ b/src/EzSystems/BehatBundle/Features/Context/Browser/SubContexts/AuthenticationContext.php
@@ -5,8 +5,8 @@
  * This class contains the implementation of the Authentication interface which
  * has the sentences for the Authentication BDD
  *
- * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
- * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
 

--- a/src/EzSystems/BehatBundle/Features/Context/Browser/SubContexts/BrowserSubContext.php
+++ b/src/EzSystems/BehatBundle/Features/Context/Browser/SubContexts/BrowserSubContext.php
@@ -4,8 +4,8 @@
  *
  * This is the parent object of all Browser sub contexts
  *
- * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
- * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
 

--- a/src/EzSystems/BehatBundle/Features/Context/FeatureContext.php
+++ b/src/EzSystems/BehatBundle/Features/Context/FeatureContext.php
@@ -4,8 +4,8 @@
  *
  * This class contains general feature context for Behat.
  *
- * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
- * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
 

--- a/src/EzSystems/BehatBundle/Features/Context/SentencesInterfaces/Authentication.php
+++ b/src/EzSystems/BehatBundle/Features/Context/SentencesInterfaces/Authentication.php
@@ -4,8 +4,8 @@
  *
  * This interface as the sentences definitions for the authentication steps
  *
- * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
- * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
 

--- a/src/EzSystems/BehatBundle/Features/Context/SentencesInterfaces/ContentTypeGroup.php
+++ b/src/EzSystems/BehatBundle/Features/Context/SentencesInterfaces/ContentTypeGroup.php
@@ -2,8 +2,8 @@
 /**
  * File containing the ContentTypeGroup interface.
  * 
- * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
- * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
 

--- a/src/EzSystems/BehatBundle/Features/Context/SentencesInterfaces/Error.php
+++ b/src/EzSystems/BehatBundle/Features/Context/SentencesInterfaces/Error.php
@@ -4,8 +4,8 @@
 *
 * This interface has the sentences definitions for the Error steps
 *
-* @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
-* @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+* @copyright Copyright (C) eZ Systems AS. All rights reserved.
+* @license For full copyright and license information view LICENSE file distributed with this source code.
 * @version //autogentag//
 */
 

--- a/src/EzSystems/BehatBundle/Helpers/ValueObjectHelper.php
+++ b/src/EzSystems/BehatBundle/Helpers/ValueObjectHelper.php
@@ -2,8 +2,8 @@
 /**
  * File containing the ValueObjectHelper class.
  *
- * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
- * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
 

--- a/src/EzSystems/BehatBundle/ObjectGivenContexts/GivenContentTypeGroupContext.php
+++ b/src/EzSystems/BehatBundle/ObjectGivenContexts/GivenContentTypeGroupContext.php
@@ -4,8 +4,8 @@
  *
  * This class contains the given steps for manipulating content type groups
  *
- * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
- * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
 

--- a/src/EzSystems/BehatBundle/ObjectGivenContexts/GivenContexts.php
+++ b/src/EzSystems/BehatBundle/ObjectGivenContexts/GivenContexts.php
@@ -4,8 +4,8 @@
  *
  * This is the parent object of all object given steps sub contexts
  *
- * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
- * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
 


### PR DESCRIPTION
_Status: Call for feedback_

This is a proposal for how to deal with copyright and license headers as proposed in https://jira.ez.no/browse/EZP-22128.

The issue proposes that we should adopt for a copyright and license header approach similar to Symfony does, see: [php file](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Config/ConfigCache.php) and [LICENSE file](https://github.com/symfony/symfony/blob/master/LICENSE). The reason for this is to simplify maintenance of the code a bit and make it simpler to deal with several licenses in the future in regards to delivering our source code (also enterprise) over composer.

Deviations taken in this PR:
- Opted to keep on using \@license php doc to simplify replacement and it is afaik supported by doc generators adding some value.

Command used (_NB: OSX flavor of sed_ NB2: does not work on legacy as files are not in utf8 always...):

``` bash
find {ezpublish/,src/,web/,bin/} -name *.php | xargs sed -i "" -e "s#@license .*\$#@license For full copyright and license information view LICENSE file distributed with this source code.#;s#@copyright .*\$#@copyright Copyright (C) eZ Systems AS. All rights reserved.#"
```

review ping @bdunogier @lolautruche @dpobel @pspanja @yannickroger @lserwatka @glye @rolandbenedetti 
