### PR TITLE
Bdd read contenttypegroup

### DIFF
--- a/src/EzSystems/BehatBundle/Features/ContentTypeGroup/create.feature
+++ b/src/EzSystems/BehatBundle/Features/ContentTypeGroup/create.feature
@@ -1,4 +1,4 @@
-@contenttypegroup @adminFeature
+@contentTypeGroup @adminFeature
 Feature: Creating a Content Type Group
     Create Content Type Group
     As an administrator or anonymous user

--- a/src/EzSystems/BehatBundle/Features/ContentTypeGroup/readAll.feature
+++ b/src/EzSystems/BehatBundle/Features/ContentTypeGroup/readAll.feature
@@ -1,24 +1,24 @@
-@contenttypegroup @adminFeature
+@contentTypeGroup @adminFeature
 Feature: Read all Content Type Groups
   Read all Content Type Groups
   As an administrator or anonymous user
   I want to know all existing Content Type Groups
 
-  Scenario: Read all ContentTypeGroups
+  Scenario: Read all Content Type Groups
     Given I am logged as an "administrator"
-    And I have the following ContentTypeGroups:
+    And I have the following Content Type Groups:
       | groups     |
       | some       |
       | dif3rent   |
       | id_nt.fier |
-    When I read ContentTypeGroups list
-    Then I see the following ContentTypeGroups:
+    When I read Content Type Groups list
+    Then I see the following Content Type Groups:
       | groups     |
       | some       |
       | dif3rent   |
       | id_nt.fier |
 
-  Scenario: Attempt to read all ContentTypeGroups with a non authorized user
+  Scenario: Attempt to read all Content Type Groups with a non authorized user
     Given I am not logged in
-    When I read ContentTypeGroups list
+    When I read Content Type Groups list
     Then I see an unauthorized error

--- a/src/EzSystems/BehatBundle/Features/Context/SentencesInterfaces/ContentTypeGroup.php
+++ b/src/EzSystems/BehatBundle/Features/Context/SentencesInterfaces/ContentTypeGroup.php
@@ -39,7 +39,7 @@ interface ContentTypeGroup
     public function iSeeTotalContentTypeGroup( $total, $identifier );
 
     /**
-     * @Then /^I see the following ContentTypeGroups:$/
+     * @Then /^I see the following Content Type Groups:$/
      */
     public function iSeeTheFollowingContentTypeGroups( TableNode $groups );
 }

--- a/src/EzSystems/BehatBundle/ObjectGivenContexts/GivenContentTypeGroupContext.php
+++ b/src/EzSystems/BehatBundle/ObjectGivenContexts/GivenContentTypeGroupContext.php
@@ -74,7 +74,7 @@ class GivenContentTypeGroupContext extends GivenContexts
     }
 
     /**
-     * @Given /^I have (?:the |)following ContentTypeGroups(?:\:|)$/
+     * @Given /^I have (?:the |)following Content Type Groups(?:\:|)$/
      */
     public function iHaveTheFollowingContentTypeGroups( TableNode $table )
     {


### PR DESCRIPTION
Depends on:

> ezsystems/ezpublish-community#131 - changes from protected/private methods to public to be accessible  from the sub contexts
> ezsystems/ezpublish-community#137 - enable REST test (without this the rest is not actually being tested)
> ezsystems/ezpublish-kernel#827 - base implementation of rest and ContentTypeGroup
> ezsystems/ezpublish-community#136 - needs ValueObjectHelper
> ezsystems/ezpublish-community#135 - the ContentTypeGroup given steps are also needed to test this
> ezsystems/ezpublish-community#139 - minor change on error sentences

To do::
- [x] Add feature file
- [x] Add sentences definitions to interface
- [x] merge ezsystems/ezpublish-community#131
- [x] merge ezsystems/ezpublish-community#137
- [x] merge ezsystems/ezpublish-kernel#827
- [x] merge ezsystems/ezpublish-community#136
- [x] merge ezsystems/ezpublish-community#135
- [x] merge ezsystems/ezpublish-community#139
