### PR TITLE
BDD: fix minor mistake in BrowserContext::checkLinkOrder()

### DIFF
--- a/src/EzSystems/BehatBundle/Features/Context/Browser/BrowserContext.php
+++ b/src/EzSystems/BehatBundle/Features/Context/Browser/BrowserContext.php
@@ -326,7 +326,7 @@ class BrowserContext extends BaseFeatureContext implements BrowserInternalSenten
         Assertion::assertEquals(
             count( $links ),
             $passed,
-            "Expected to evaluate '{count( $links )}' links evaluated '{$passed}'"
+            "Expected to evaluate '" . count( $links ) . "' links evaluated '{$passed}'"
         );
     }
 


### PR DESCRIPTION
minor mistake on assertion giving a false positive.

This is needed for 

> ezsystems/DemoBundle#73
