### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "sensio/generator-bundle": "2.3.*",
         "incenteev/composer-parameter-handler": "~2.0",
         "tedivm/stash-bundle": "0.3.*",
-        "ezsystems/ezpublish-kernel": "5.3.*@dev",
+        "ezsystems/ezpublish-kernel": "@dev",
         "ezsystems/ezpublish-legacy": "@dev",
         "ezsystems/demobundle": "@dev",
         "ezsystems/comments-bundle": "@dev",


### PR DESCRIPTION
Fixed the ezpublish-kernel version since having "5.3.*@dev" breaks composer install command
