### PR TITLE
Fix EZP-22955: index_*.php files are not passed on to FPM socket/network

### DIFF
--- a/doc/nginx/etc/nginx/ez_params.d/ez_rewrite_params
+++ b/doc/nginx/etc/nginx/ez_params.d/ez_rewrite_params
@@ -1,14 +1,14 @@
 
 # Some custom rewrite (for eztag) TODO needed ?
-rewrite "^tags/treemenu/?" "index_treemenu_tags.php" break;
-rewrite "^index_treemenu_tags\.php" "/index_treemenu_tags.php" break;
+rewrite "^tags/treemenu/?" "index_treemenu_tags.php" last;
+rewrite "^index_treemenu_tags\.php" "/index_treemenu_tags.php" last;
 
 # v1 rest API is on Legacy
-rewrite "^/api/[^/]+/v1" "/index_rest.php" break;
+rewrite "^/api/[^/]+/v1" "/index_rest.php" last;
 
 # If using cluster, uncomment the following two lines:
-#rewrite "^/var/([^/]+/)?storage/images(-versioned)?/(.*)" "/index_cluster.php" break;
-#rewrite "^/var/([^/]+/)?cache/(texttoimage|public)/(.*)" "/index_cluster.php" break;
+#rewrite "^/var/([^/]+/)?storage/images(-versioned)?/(.*)" "/index_cluster.php" last;
+#rewrite "^/var/([^/]+/)?cache/(texttoimage|public)/(.*)" "/index_cluster.php" last;
 
 rewrite "^/var/([^/]+/)?storage/images(-versioned)?/(.*)" "/var/$1storage/images$2/$3" break;
 rewrite "^/var/([^/]+/)?cache/(texttoimage|public)/(.*)" "/var/$1cache/$2/$3" break;

--- a/doc/nginx/etc/nginx/sites-available/mysite.com
+++ b/doc/nginx/etc/nginx/sites-available/mysite.com
@@ -21,7 +21,7 @@ server {
     include ez_params.d/ez_rewrite_params;
 
     location / {
-        location ~ ^/(index|index_rest)\.php(/|$) {
+        location ~ ^/(index|index_(rest|cluster|treemenu_tags))\.php(/|$) {
             include ez_params.d/ez_fastcgi_params;
 
             # FPM socket


### PR DESCRIPTION
The rewrite flags are described [here](http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#rewrite).
