### PR TITLE
Moved cluster configuration to an external file

### DIFF
--- a/doc/nginx/etc/nginx/ez_params.d/ez_cluster_rewrite_params
+++ b/doc/nginx/etc/nginx/ez_params.d/ez_cluster_rewrite_params
@@ -1,0 +1,2 @@
+rewrite "^/var/([^/]+/)?storage/images(-versioned)?/(.*)" "/index_cluster.php" break;
+rewrite "^/var/([^/]+/)?cache/(texttoimage|public)/(.*)" "/index_cluster.php" break;

--- a/doc/nginx/etc/nginx/ez_params.d/ez_rewrite_params
+++ b/doc/nginx/etc/nginx/ez_params.d/ez_rewrite_params
@@ -1,14 +1,9 @@
-
 # Some custom rewrite (for eztag) TODO needed ?
 rewrite "^tags/treemenu/?" "index_treemenu_tags.php" last;
 rewrite "^index_treemenu_tags\.php" "/index_treemenu_tags.php" last;
 
 # v1 rest API is on Legacy
 rewrite "^/api/[^/]+/v1" "/index_rest.php" last;
-
-# If using cluster, uncomment the following two lines:
-#rewrite "^/var/([^/]+/)?storage/images(-versioned)?/(.*)" "/index_cluster.php" last;
-#rewrite "^/var/([^/]+/)?cache/(texttoimage|public)/(.*)" "/index_cluster.php" last;
 
 rewrite "^/var/([^/]+/)?storage/images(-versioned)?/(.*)" "/var/$1storage/images$2/$3" break;
 rewrite "^/var/([^/]+/)?cache/(texttoimage|public)/(.*)" "/var/$1cache/$2/$3" break;

--- a/doc/nginx/etc/nginx/sites-available/mysite.com
+++ b/doc/nginx/etc/nginx/sites-available/mysite.com
@@ -17,6 +17,9 @@ server {
     ## and make sure to comment these out in DEV environment.
     include ez_params.d/ez_prod_rewrite_params;
 
+    # ez cluster rewrite rules, uncomment if vhost uses clustering
+    #include ez_params.d/ez_cluster_rewrite_params;
+
     # ez rewrite rules
     include ez_params.d/ez_rewrite_params;
 


### PR DESCRIPTION
This moves the cluster rewrite out of the main rewrite file, so that clustering is optional for each site.
