### PR TITLE
Add rest_client setting

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -2,8 +2,8 @@ default:
     context:
         parameters:
             rest_url: 'http://localhost'
-            # rest_client possible options [GuzzleDriver|BuzzDriver]
-            rest_client: BuzzDriver
+            # rest_driver possible options [GuzzleDriver|BuzzDriver]
+            rest_driver: BuzzDriver
     paths:
         features: vendor/ezsystems/
 


### PR DESCRIPTION
This PR and the ezsystems/ezpublish-kernel#962 PR are to make possible to choose the rest driver to use on the REST BDD testing.

This needs ezsystems/ezpublish-kernel#962
