### PR TITLE
Add profile to test legacy admin2

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -54,7 +54,7 @@ restApi:
     paths:
         features: vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features
 
-admin2:
+legacyAdmin:
     context:
         class: eZ\Bundle\EzPublishLegacyBundle\Features\Context\Admin2Context
     paths:


### PR DESCRIPTION
Add profile so that's possible to test admin2 interface.

This can be ran like the others: `$ bin/behat -p admin2`
