### PR TITLE
EZP-23339: use correct 'xargs sudo chmod' order

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -83,8 +83,8 @@
 
        ```bash
        $ sudo chown -R www-data:www-data ezpublish/{cache,logs,config,sessions} ezpublish_legacy/{design,extension,settings,var} web
-       $ sudo find {ezpublish/{cache,logs,config,sessions},ezpublish_legacy/{design,extension,settings,var},web} -type d | sudo xargs chmod -R 775
-       $ sudo find {ezpublish/{cache,logs,config},ezpublish_legacy/{design,extension,settings,var},web} -type f | sudo xargs chmod -R 664
+       $ sudo find {ezpublish/{cache,logs,config,sessions},ezpublish_legacy/{design,extension,settings,var},web} -type d | xargs sudo chmod -R 775
+       $ sudo find {ezpublish/{cache,logs,config},ezpublish_legacy/{design,extension,settings,var},web} -type f | xargs sudo chmod -R 664
        ```
 
        D. **Using chmod**
@@ -92,8 +92,8 @@
        If you can't use ACL and aren't allowed to change owner, you can use chmod, making the files writable by everybody. Note that this method really isn't recommended as it allows any user to do anything.
 
        ```bash
-       $ sudo find {ezpublish/{cache,logs,config,sessions},ezpublish_legacy/{design,extension,settings,var},web} -type d | sudo xargs chmod -R 777
-       $ sudo find {ezpublish/{cache,logs,config,sessions},ezpublish_legacy/{design,extension,settings,var},web} -type f | sudo xargs chmod -R 666
+       $ sudo find {ezpublish/{cache,logs,config,sessions},ezpublish_legacy/{design,extension,settings,var},web} -type d | xargs sudo chmod -R 777
+       $ sudo find {ezpublish/{cache,logs,config,sessions},ezpublish_legacy/{design,extension,settings,var},web} -type f | xargs sudo chmod -R 666
        ```
 
 ## Configure the system


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23339

This is a nitpick on the install doc: instead of running `xargs` as sudo, only run the actual (`chmod`) command.
Besides the nitpick, this makes it possible to use bash aliases etc without breakage from sudo prompt(s).

In addition, AFAICT `sudo find` seems unnecessary - any user with access to ezproot should have read permissions for the remainder of the necessary files/folders, in which case simply `find` is sufficient.