### PR TITLE
Fix EZP-23344 render_hinclude not working with nginx

### DIFF
--- a/doc/nginx/etc/nginx/ez_params.d/ez_rewrite_params
+++ b/doc/nginx/etc/nginx/ez_params.d/ez_rewrite_params
@@ -38,5 +38,5 @@ rewrite "^/w3c/p3p\.xml" "/w3c/p3p.xml" break;
 # Following rule is needed to correctly display assets from eZ Publish5 / Symfony bundles
 rewrite "^/bundles/(.*)" "/bundles/$1" break;
 
-rewrite "^(.*)$" "/index.php?$1" last;
+rewrite "^(.*)$" "/index.php$1" last;
 


### PR DESCRIPTION
Fixes https://jira.ez.no/browse/EZP-23344

Installing ezpublish-community in nginx and following exactly the instructions given in https://github.com/ezsystems/ezpublish-community/blob/master/doc/nginx/nginx.rst makes render_hinclude calls throw a error 500.

If fact, a AccessDeniedHttpException is thrown from the symfony [FragmentListener](https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/HttpKernel/EventListener/FragmentListener.php#L88).

Doing some debug i found that there seems to be a problem with the way the urls was given to the urlSigner in order to know if request are valid of not.
Basically, while in apache uris from the hinclude call are in this way

```
http://[host]/_fragment?_path=...
```

with nginx urls seems to add another _fragment. like this

```
http://[host]/_fragment?/_fragment&_path=...
```

Because of that, signer seems to doesn't trust the url and throws the Exception.

I think this is because last nite in the provided rewrite rules where the `?` is not needed. 
