### PR TITLE
EZP-22280: Added LiipImagineBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "nelmio/cors-bundle": "~1.3",
         "hautelook/templated-uri-bundle": "~1.0",
         "doctrine/dbal": "~2.5@beta",
-        "doctrine/doctrine-bundle": "~1.3@beta"
+        "doctrine/doctrine-bundle": "~1.3@beta",
+        "liip/imagine-bundle": "~1.0"
     },
     "conflict": {
         "symfony/symfony": "2.3.9 | 2.3.14 | 2.3.15"

--- a/ezpublish/EzPublishKernel.php
+++ b/ezpublish/EzPublishKernel.php
@@ -17,6 +17,7 @@ use EzSystems\DemoBundle\EzSystemsDemoBundle;
 use EzSystems\BehatBundle\EzSystemsBehatBundle;
 use eZ\Bundle\EzPublishCoreBundle\Kernel;
 use EzSystems\NgsymfonytoolsBundle\EzSystemsNgsymfonytoolsBundle;
+use Liip\ImagineBundle\LiipImagineBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
@@ -56,6 +57,7 @@ class EzPublishKernel extends Kernel
             new DoctrineBundle(),
             new TedivmStashBundle(),
             new HautelookTemplatedUriBundle(),
+            new LiipImagineBundle(),
             new EzPublishCoreBundle(),
             new EzPublishLegacyBundle( $this ),
             new EzSystemsDemoBundle(),

--- a/ezpublish/config/routing.yml
+++ b/ezpublish/config/routing.yml
@@ -21,5 +21,8 @@ _ezpublishRestOptionsRoutes:
     prefix: %ezpublish_rest.path_prefix%
     type: rest_options
 
+_liip_imagine:
+    resource: "@LiipImagineBundle/Resources/config/routing.xml"
+
 _ezpublishDemoRoutes:
     resource: "@eZDemoBundle/Resources/config/routing.yml"


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-22280
> Depends on https://github.com/ezsystems/ezpublish-kernel/pull/952

Just adds `LiipImagineBundle` to the kernel.
