### PR TITLE
Fix EZP-23392: Notice when using the REST API after upgrading Symfony to 2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "white-october/pagerfanta-bundle": "1.0.*",
         "whiteoctober/breadcrumbs-bundle": "~1.0.1",
         "nelmio/cors-bundle": "~1.3",
-        "hautelook/templated-uri-bundle": "~1.0",
+        "hautelook/templated-uri-bundle": "~1.0 | ~2.0",
         "doctrine/dbal": "~2.5@beta",
         "doctrine/doctrine-bundle": "~1.3@beta"
     },


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23392
# Description

TemplateUriBundle 2.0 is compatible with Symfony 2.5, 1.0 is for Symfony 2.3.

ping @sunpietro
