### PR TITLE
EZP-23328: IO interfaces split

### DIFF
--- a/ezpublish/EzPublishKernel.php
+++ b/ezpublish/EzPublishKernel.php
@@ -36,6 +36,7 @@ use Nelmio\CorsBundle\NelmioCorsBundle;
 use Hautelook\TemplatedUriBundle\HautelookTemplatedUriBundle;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Knp\Bundle\MenuBundle\KnpMenuBundle;
+use Oneup\FlysystemBundle\OneupFlysystemBundle;
 
 class EzPublishKernel extends Kernel
 {
@@ -69,7 +70,8 @@ class EzPublishKernel extends Kernel
             new WhiteOctoberPagerfantaBundle(),
             new WhiteOctoberBreadcrumbsBundle(),
             new NelmioCorsBundle(),
-            new KnpMenuBundle()
+            new KnpMenuBundle(),
+            new OneupFlysystemBundle()
         );
 
         switch ( $this->getEnvironment() )


### PR DESCRIPTION
> Related PR: ezsystems/ezpublish-kernel#1017
> Status: just to run BDD tests for now

Adds `OneupFlysystemBundle` to the kernel.
## TODO
- [ ] Revert 49a99ba before merging
- [x] Change NS syntax in kernel
