### PR TITLE
EZP-23437: rewrite rules update for nginx

### DIFF
--- a/doc/nginx/etc/nginx/ez_params.d/ez_cluster_rewrite_params
+++ b/doc/nginx/etc/nginx/ez_params.d/ez_cluster_rewrite_params
@@ -1,2 +1,2 @@
-rewrite "^/var/([^/]+/)?storage/images(-versioned)?/(.*)" "/index_cluster.php" break;
+rewrite "^/var/([^/]+/)?storage/images(-versioned)?/(.*)" "/index.php" break;
 rewrite "^/var/([^/]+/)?cache/(texttoimage|public)/(.*)" "/index_cluster.php" break;

--- a/doc/nginx/etc/nginx/sites-available/mysite.com
+++ b/doc/nginx/etc/nginx/sites-available/mysite.com
@@ -17,7 +17,7 @@ server {
     ## and make sure to comment these out in DEV environment.
     include ez_params.d/ez_prod_rewrite_params;
 
-    # ez cluster rewrite rules, uncomment if vhost uses clustering
+    # ezlegacy cluster rewrite rules, uncomment if vhost uses DFS clustering
     #include ez_params.d/ez_cluster_rewrite_params;
 
     # ez rewrite rules


### PR DESCRIPTION
> Required by [EZP-23437](http://jira.ez.no/browse/EZP-23437) / ezsystems/ezpublish-kernel#1031

Stored images (`var/[dir/]images[-versioned]/*`) are now sent to Sf's `index.php` instead of legacy's `index_cluster.php`
