### PR TITLE
EZP-23494: Sync eZ Publish 5.4/2014.09 with Symfony-standard 2.5

### DIFF
--- a/ezpublish/config/config.yml
+++ b/ezpublish/config/config.yml
@@ -4,9 +4,9 @@ imports:
 
 framework:
     esi:             ~
-    translator:      { fallback: %locale_fallback% }
+    translator:      { fallback: "%locale_fallback%" }
     # The secret parameter is used to generate CSRF tokens
-    secret:          %secret%
+    secret:          "%secret%"
     router:
         resource: "%kernel.root_dir%/config/routing.yml"
         strict_requirements: %kernel.debug%
@@ -24,30 +24,31 @@ framework:
     trusted_proxies: ~
     trusted_hosts: []
     session:
-        save_path: "%kernel.root_dir%/sessions"
-        # The session name defined here will be overridden by the one defined in your ezpublish.yml, for your siteaccess.
-        # Defaut session name is "eZSESSID{siteaccess_hash}" (unique session name per siteaccess).
-        # See ezpublish.yml.example for an example on how to configure this.
+        # handler_id set to null will use default session handler from php.ini
+        handler_id:  ~
+        # Note: eZ Publish also allows session name and session cookie configuration to be per SiteAccess, by
+        #       default session name will be set to "eZSESSID{siteaccess_hash}" (unique session name per siteaccess)
+        #       Further reading: https://doc.ez.no/display/EZP/Session+configuration
     fragments:       ~
     http_method_override: true
 
 # Twig Configuration
 twig:
-    debug:            %kernel.debug%
-    strict_variables: %kernel.debug%
+    debug:            "%kernel.debug%"
+    strict_variables: "%kernel.debug%"
 
 # Assetic Configuration
 assetic:
-    debug:          %kernel.debug%
+    debug:          "%kernel.debug%"
     use_controller: false
     bundles:        [ eZDemoBundle ]
     #java: /usr/bin/java
     filters:
         cssrewrite: ~
         #closure:
-        #    jar: %kernel.root_dir%/Resources/java/compiler.jar
+        #    jar: "%kernel.root_dir%/Resources/java/compiler.jar"
         #yui_css:
-        #    jar: %kernel.root_dir%/Resources/java/yuicompressor-2.4.7.jar
+        #    jar: "%kernel.root_dir%/Resources/java/yuicompressor-2.4.7.jar"
 
 ez_publish_legacy:
     enabled: true

--- a/ezpublish/config/config_dev.yml
+++ b/ezpublish/config/config_dev.yml
@@ -6,21 +6,40 @@ framework:
     profiler: { only_exceptions: false }
 
 web_profiler:
-    toolbar: true
-    intercept_redirects: false
+    toolbar: "%debug_toolbar%"
+    intercept_redirects: "%debug_redirects%"
 
 monolog:
     handlers:
         main:
-            type:  stream
-            path:  %kernel.logs_dir%/%kernel.environment%.log
-            level: debug
-        firephp:
-            type:  firephp
-            level: info
-        chromephp:
-            type:  chromephp
-            level: info
+            type:   stream
+            path:   "%kernel.logs_dir%/%kernel.environment%.log"
+            level:  debug
+# Symfony 2.6
+#        console:
+#            type:   console
+#            bubble: false
+#            verbosity_levels:
+#                VERBOSITY_VERBOSE: INFO
+#                VERBOSITY_VERY_VERBOSE: DEBUG
+#            channels: ["!doctrine"]
+#        console_very_verbose:
+#            type:   console
+#            bubble: false
+#            verbosity_levels:
+#                VERBOSITY_VERBOSE: NOTICE
+#                VERBOSITY_VERY_VERBOSE: NOTICE
+#                VERBOSITY_DEBUG: DEBUG
+#            channels: ["doctrine"]
+
+        # uncomment to get logging in your browser
+        # you may have to allow bigger header sizes in your Web server configuration
+        #firephp:
+        #    type:   firephp
+        #    level:  info
+        #chromephp:
+        #    type:   chromephp
+        #    level:  info
 
 assetic:
-    use_controller: true
+    use_controller: "%use_assetic_controller%"

--- a/ezpublish/config/config_prod.yml
+++ b/ezpublish/config/config_prod.yml
@@ -25,5 +25,7 @@ monolog:
             handler:      nested
         nested:
             type:  stream
-            path:  %kernel.logs_dir%/%kernel.environment%.log
+            path:  "%kernel.logs_dir%/%kernel.environment%.log"
             level: debug
+        console:
+            type:  console

--- a/ezpublish/config/config_test.yml
+++ b/ezpublish/config/config_test.yml
@@ -6,7 +6,7 @@ framework:
     session:
         storage_id: session.storage.mock_file
     profiler:
-        enabled: false
+        collect: false
 
 web_profiler:
     toolbar: false

--- a/ezpublish/config/parameters.yml.dist
+++ b/ezpublish/config/parameters.yml.dist
@@ -1,4 +1,11 @@
+# This file is a "template" of what your parameters.yml file should look like
 parameters:
+    # A secret key that's used to generate certain security-related tokens
     secret: ThisTokenIsNotSoSecretChangeIt
     locale_fallback: en
     ezpublish_legacy.default.view_default_layout: eZDemoBundle::pagelayout.html.twig
+
+    # Settings to control dev environment settings
+    debug_toolbar:          true
+    debug_redirects:        false
+    use_assetic_controller: true

--- a/ezpublish/config/routing_dev.yml
+++ b/ezpublish/config/routing_dev.yml
@@ -10,5 +10,10 @@ _configurator:
     resource: "@SensioDistributionBundle/Resources/config/routing/webconfigurator.xml"
     prefix:   /_configurator
 
+# Symfony 2.6
+#_errors:
+#    resource: "@TwigBundle/Resources/config/routing/errors.xml"
+#    prefix:   /_error
+
 _main:
     resource: routing.yml

--- a/ezpublish/config/security.yml
+++ b/ezpublish/config/security.yml
@@ -1,23 +1,13 @@
 security:
-    encoders:
-        Symfony\Component\Security\Core\User\User: plaintext
-
-    role_hierarchy:
-        ROLE_ADMIN:       ROLE_USER
-        ROLE_SUPER_ADMIN: [ROLE_USER, ROLE_ADMIN, ROLE_ALLOWED_TO_SWITCH]
-
     providers:
         ezpublish:
             id: ezpublish.security.user_provider
 #        in_memory:
-#            memory:
-#                users:
-#                    user:  { password: userpass, roles: [ 'ROLE_USER' ] }
-#                    admin: { password: adminpass, roles: [ 'ROLE_ADMIN' ] }
+#            memory: ~
 
     firewalls:
         dev:
-            pattern:  ^/(_(profiler|wdt)|css|images|js)/
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
 
         ezpublish_setup:
@@ -37,18 +27,5 @@ security:
                 require_previous_session: false
             logout: ~
 
-#        secured_area:
-#            pattern:    ^/demo/secured/
-#            form_login:
-#                check_path: /demo/secured/login_check
-#                login_path: /demo/secured/login
-#            logout:
-#                path:   /demo/secured/logout
-#                target: /demo/
-            #anonymous: ~
-            #http_basic:
-            #    realm: "Secured Demo Area"
-
-    access_control:
-        #- { path: ^/_internal/secure, roles: IS_AUTHENTICATED_ANONYMOUSLY, ip: 127.0.0.1 }
-        #- { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }
+        default:
+            anonymous: ~

--- a/ezpublish/phpunit.xml.dist
+++ b/ezpublish/phpunit.xml.dist
@@ -1,22 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
-<phpunit
-    backupGlobals               = "false"
-    backupStaticAttributes      = "false"
-    colors                      = "true"
-    convertErrorsToExceptions   = "true"
-    convertNoticesToExceptions  = "true"
-    convertWarningsToExceptions = "true"
-    processIsolation            = "false"
-    stopOnFailure               = "false"
-    syntaxCheck                 = "false"
-    bootstrap                   = "bootstrap.php.cache" >
+<!-- http://phpunit.de/manual/4.1/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="bootstrap.php.cache"
+>
 
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>../src/*/*Bundle/Tests</directory>
             <directory>../src/*/Bundle/*Bundle/Tests</directory>
+            <directory>../src/*Bundle/Tests</directory>
         </testsuite>
     </testsuites>
 
@@ -37,5 +33,4 @@
             </exclude>
         </whitelist>
     </filter>
-
 </phpunit>


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-23494

Changes stuff to be in sync with symfony-standard, for instance uses php's session save handler out of the box.

Changes taken mainly from this diff: https://github.com/symfony/symfony-standard/compare/2.3...v2.5.5
