### PR TITLE
Fix: EZP-23500 - _configurator route shouldn't be present on dev environment

### DIFF
--- a/ezpublish/config/routing_dev.yml
+++ b/ezpublish/config/routing_dev.yml
@@ -6,10 +6,6 @@ _profiler:
     resource: "@WebProfilerBundle/Resources/config/routing/profiler.xml"
     prefix:   /_profiler
 
-_configurator:
-    resource: "@SensioDistributionBundle/Resources/config/routing/webconfigurator.xml"
-    prefix:   /_configurator
-
 # Symfony 2.6
 #_errors:
 #    resource: "@TwigBundle/Resources/config/routing/errors.xml"


### PR DESCRIPTION
### EZP-23500 - _configurator route shouldn't be present on dev environment

Apparently the routing_dev.yml file has the _configurator route present, by being enable this allows to inject fields into parameters.yml
