### PR TITLE
[Testing] Bump Symfony version to 2.6@beta

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": ">=5.3.17",
-        "symfony/symfony": "~2.5",
+        "symfony/symfony": "~2.6@beta",
         "twig/extensions": "~1.0",
         "symfony/assetic-bundle": "~2.3",
         "symfony/swiftmailer-bundle": "~2.3",
@@ -34,7 +34,6 @@
         "hautelook/templated-uri-bundle": "~1.0 | ~2.0",
         "doctrine/dbal": "~2.5@rc",
         "doctrine/doctrine-bundle": "~1.3@beta",
-        "symfony/expression-language": "~2.4",
         "sensio/framework-extra-bundle": "~3.0"
     },
     "require-dev": {


### PR DESCRIPTION
- [ ] Make sure to re sync settings with symfony 2.6, they recently removed some of the params again
- [ ] Someone need to look at the REST failure
