### PR TITLE
Fix EZP-23159: clear project container cache pre composer install/update

### DIFF
--- a/bin/clear-container-cache.sh
+++ b/bin/clear-container-cache.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# clear project container cache in ezpublish/cache/<env>/
+find ./ezpublish/cache/ -maxdepth 2 -name ezpublish*ProjectContainer.php | xargs rm -f

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,12 @@
         "ezsystems/behatbundle": "@dev"
     },
     "scripts": {
+        "pre-install-cmd": [
+            "bin/clear-container-cache.sh"
+        ],
+        "pre-update-cmd": [
+            "bin/clear-container-cache.sh"
+        ],
         "post-install-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",


### PR DESCRIPTION
Problem: when updating eZ Publish through composer, any service change can potentially break the process with fatal errors/exceptions.

The usual fix is then to `rm -rf ezpublish/cache/*`

However, it should NOT be necessary to fully clear all the caches, as it is an issue specific to the project configuration container.
This introduces a new script to remove such files, as well as composer.json pre-install / pre-update cmds.


Note:
With the change on this PR, I am not certain if the `"Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache"` cmd is still absolutely necessary, or optional on most cases.