### PR TITLE
EZP-22839: Removed ezpublish.default.view_default_layout setting

### DIFF
--- a/ezpublish/config/parameters.yml.dist
+++ b/ezpublish/config/parameters.yml.dist
@@ -9,8 +9,6 @@ parameters:
     mailer_user:       ~
     mailer_password:   ~
 
-    ezpublish_legacy.default.view_default_layout: eZDemoBundle::pagelayout.html.twig
-
     # Settings to control dev environment settings
     debug_toolbar:          true
     debug_redirects:        false


### PR DESCRIPTION
It's no longer needed since it's defined via semantic config for DemoBundle in https://github.com/ezsystems/DemoBundle/pull/121.
