### PR TITLE
[BDD] configure no suites for default profile.

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -18,6 +18,9 @@ default:
                 env: behat
                 debug: false
 
+    # default profile: no suites
+    suites: ~
+
 rest:
     suites:
         fullJson:


### PR DESCRIPTION
When executing `bin/behat` without specifying a profile, an exception is thrown:

```
  [Behat\Behat\Context\Exception\ContextNotFoundException]
  `FeatureContext` context class not found and can not be used.
```

This explicitly configures behat.yml with no suites for default profile, which results in:

```
$ php bin/behat
No scenarios
No steps
0m0.00s (29.85Mb)
```
