### PR TITLE
Move behat.yml to behat.yml.dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ composer.lock
 .buildpath
 .project
 .settings/
-
+behat.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,11 @@ before_script:
   # since setup wizard need to actually work to the other test suites to pass
   # moved it to before_script so that the random timeout on package fetching
   # don't fail travis
-  - php bin/behat --profile setupWizard --suite $INSTALL
+  - php bin/behat -c behat.yml.dist --profile setupWizard --suite $INSTALL
 
 # execute behat as the script command
 script:
-  - php bin/behat -vv --profile $PROFILE --suite $TEST
+  - php bin/behat -c behat.yml.dist -vv --profile $PROFILE --suite $TEST
 
 # disable mail notifications
 notification:

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -1,3 +1,5 @@
+# This file contains the default configuration for behat testing using EzSystems/BehatBundle
+
 default:
     extensions:
         Behat\MinkExtension:
@@ -25,21 +27,21 @@ rest:
     suites:
         fullJson:
             paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features ]
-            contexts: 
+            contexts:
                 - eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext:
                     url: http://localhost/api/ezp/v2/
                     driver: BuzzDriver
                     type: json
         fullXml:
             paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features ]
-            contexts: 
+            contexts:
                 - eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext:
                     url: http://localhost/api/ezp/v2/
                     driver: BuzzDriver
                     type: xml
         guzzle:
             paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features ]
-            contexts: 
+            contexts:
                 - eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext:
                     url: http://localhost/api/ezp/v2/
                     driver: GuzzleDriver


### PR DESCRIPTION
behat config can require changes to match the current environment (most notably the hostname/url),
as well as any other custom configurations.

For this reason, ideally it should be kept outside of git repo, and instead use a default/dist file
(much in the same way as ezpublish.yml)

This changes the file name, updates travis script accordingly, and updates .gitignore.
