### PR TITLE
Bump Symfony requirement to ~2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "psr-0": { "": "src/" }
     },
     "require": {
-        "php": ">=5.3.17",
-        "symfony/symfony": "~2.5.0",
+        "php": ">=5.4.4",
+        "symfony/symfony": "~2.6",
         "twig/extensions": "~1.0",
         "symfony/assetic-bundle": "~2.3",
         "symfony/swiftmailer-bundle": "~2.3",


### PR DESCRIPTION
See https://github.com/ezsystems/ezpublish-kernel/pull/1111

Also fixed PHP requirement. Now in sync with ezpublish-kernel
