### PR TITLE
EZP-23783: Assetic rules in Apache2 virtual host are not used when prod environment is used by default if ENVIRONMENT variable is omitted

### DIFF
--- a/doc/apache2/vhost.template
+++ b/doc/apache2/vhost.template
@@ -111,8 +111,9 @@
         # Following rule is needed to correctly display assets from eZ Publish5 / Symfony bundles
         RewriteRule ^/bundles/ - [L]
 
-        # Additional Assetic rules for prod env, remember to run php ezpublish/console assetic:dump --env=prod
-        RewriteCond %{ENV:ENVIRONMENT} "prod"
+        # Additional Assetic rules for environments different from dev,
+        # remember to run php ezpublish/console assetic:dump --env=prod
+        RewriteCond %{ENV:ENVIRONMENT} !("dev")
         RewriteRule ^/(css|js)/.*\.(css|js) - [L]
 
         # Conditions for enabling webdav and soap interfaces from legacy


### PR DESCRIPTION
Fixes Assetic rules in Apache2 virtual host when prod environment is used by default if ENVIRONMENT variable is omitted.

With this change the Assetic rewrite rule is only used for environments different from dev, so prod environment will use the Assetic rules without having to declare the ENVIRONMENT variable.
