### PR TITLE
Speed up travis by caching composer dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ env:
   - INSTALL="demoCleanNonUniqueDB" PROFILE="rest" TEST="fullJson"
   - INSTALL="demoCleanNonUniqueDB" PROFILE="rest" TEST="fullXml"
 
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache
 
 # test only master (+ Pull requests)
 branches:


### PR DESCRIPTION
The travis build process can be significantly be sped up by caching the composer dependencies between builds.

See http://docs.travis-ci.com/user/caching/

Cheers
:octocat: Jérôme

PS: The change will obviously only take effect starting with the second build :).