### PR TITLE
Fix EZP-23884: Nginx template misses semicolon for most of the fastcgi_params

### DIFF
--- a/doc/nginx/etc/nginx/sites-available/mysite.com
+++ b/doc/nginx/etc/nginx/sites-available/mysite.com
@@ -46,42 +46,42 @@ server {
             # Whether to use custom ClassLoader (autoloader) file
             # Needs to be a valid path relative to root web/ directory
             # Defaults to bootstrap.php.cache, or autoload.php in debug, supported on 2015.01 and higher
-            #fastcgi_param CUSTOM_CLASSLOADER_FILE "../ezpublish/autoload.php"
+            #fastcgi_param CUSTOM_CLASSLOADER_FILE "../ezpublish/autoload.php";
 
             # Whether to use Symfony's ApcClassLoader.
             # Possible values: 0 or 1
             # Defaults to 0 if omitted, supported on 5.2 and higher
             #! Not supported as of 2015.01, use CUSTOM_CLASSLOADER_FILE instead for this.
-            #fastcgi_param USE_APC_CLASSLOADER 0
+            #fastcgi_param USE_APC_CLASSLOADER 0;
 
             # Prefix used when USE_APC_CLASSLOADER is set to 1.
             # Use a unique prefix in order to prevent cache key conflicts
             # with other applications also using APC.
             # Defaults to "ezpublish" if omitted, supported on 5.2 and higher
             #! Not supported as of 2015.01, use CUSTOM_CLASSLOADER_FILE instead for this.
-            #fastcgi_param APC_CLASSLOADER_PREFIX "ezpublish"
+            #fastcgi_param APC_CLASSLOADER_PREFIX "ezpublish";
 
             # Whether to use debugging.
             # Possible values: 0 or 1
             # Defaults to 0 if omitted, unless ENVIRONMENT is set to: "dev", supported on 5.2 and higher
-            #fastcgi_param USE_DEBUGGING 0
+            #fastcgi_param USE_DEBUGGING 0;
 
             # Whether to use Symfony's HTTP Caching.
             # Disable it if you are using an external reverse proxy (e.g. Varnish)
             # Possible values: 0 or 1
             # Defaults to 1 if omitted, unless ENVIRONMENT is set to: "dev", supported on 5.2 and higher
-            #fastcgi_param USE_HTTP_CACHE 1
+            #fastcgi_param USE_HTTP_CACHE 1;
 
             # Whether to use custom HTTP Cache class if USE_HTTP_CACHE is enabled
             # Value must be na autoloadable cache class
             # Defaults to "EzPublishCache", supported on 2015.01 and higher
-            #fastcgi_param HTTP_CACHE_CLASS "\Vendor\Project\MyCache"
+            #fastcgi_param HTTP_CACHE_CLASS "\Vendor\Project\MyCache";
 
             # Defines the proxies to trust.
             # Separate entries by a comma
             # Example: "proxy1.example.com,proxy2.example.org"
             # By default, no trusted proxies are set, supported on 5.2 and higher
-            #fastcgi_param TRUSTED_PROXIES "%PROXY%"
+            #fastcgi_param TRUSTED_PROXIES "%PROXY%";
         }
     }
 


### PR DESCRIPTION
Fixes: https://jira.ez.no/browse/EZP-23884

it happens that if you just uncomment one of the lines and restart your nginx you have a syntax error in your vhost because semicolon is missed at the end.

This could save me some headache in the future.

Let me know if you prefer me to create an issue for this. 