### PR TITLE
EZP-23869: Make legacy optional

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -57,28 +57,28 @@ legacyAdmin:
             base_url: http://localhost/behat_site_admin
     suites:
         full:
-            paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishLegacyBundle/Features/Admin ]
+            paths: [ vendor/ezsystems/legacy-bridge/bundle/Features/Admin ]
             contexts: [ eZ\Bundle\EzPublishLegacyBundle\Features\Context\Admin\Context ]
 
 setupWizard:
     suites:
         demoContent:
-            paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishLegacyBundle/Features/SetupWizard ]
+            paths: [ vendor/ezsystems/legacy-bridge/bundle/Features/SetupWizard ]
             contexts: [ eZ\Bundle\EzPublishLegacyBundle\Features\Context\SetupWizard\Context ]
             filters:
                 tags: '@demo && ~@clean && ~@skipByDefault'
         demoClean:
-            paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishLegacyBundle/Features/SetupWizard ]
+            paths: [ vendor/ezsystems/legacy-bridge/bundle/Features/SetupWizard ]
             contexts: [ eZ\Bundle\EzPublishLegacyBundle\Features\Context\SetupWizard\Context ]
             filters:
                 tags: '@demo && ~@content && ~@skipByDefault'
         demoContentNonUniqueDB:
-            paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishLegacyBundle/Features/SetupWizard ]
+            paths: [ vendor/ezsystems/legacy-bridge/bundle/Features/SetupWizard ]
             contexts: [ eZ\Bundle\EzPublishLegacyBundle\Features\Context\SetupWizard\Context ]
             filters:
                 tags: '@demo && ~@clean && ~@uniqueDatabaseSystem'
         demoCleanNonUniqueDB:
-            paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishLegacyBundle/Features/SetupWizard ]
+            paths: [ vendor/ezsystems/legacy-bridge/bundle/Features/SetupWizard ]
             contexts: [ eZ\Bundle\EzPublishLegacyBundle\Features\Context\SetupWizard\Context ]
             filters:
                 tags: '@demo && ~@content && ~@uniqueDatabaseSystem'

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "incenteev/composer-parameter-handler": "~2.0",
         "tedivm/stash-bundle": "0.4.*",
         "ezsystems/ezpublish-kernel": "dev-master",
-        "ezsystems/ezpublish-legacy": "dev-master",
+        "ezsystems/legacy-bridge": "dev-master",
         "ezsystems/platform-ui-bundle": "dev-master",
         "ezsystems/platform-ui-assets-bundle": "~0.1",
         "ezsystems/demobundle": "dev-master",


### PR DESCRIPTION
> See [EZP-23869](https://jira.ez.no/browse/EZP-23869)
> Linked to ezsystems/ezpublish-kernel/pull/1147

## Actual changes
Require `ezsystems/legacy-bridge` instead of `ezsystems/ezpublish-legacy`.

## Changes to tests
Path to Legacy based tests have been updated to reflect the structure change.

## TODO
- [x] **[before merging]** remove [deleteme] comments
- [x] Move dependency on legacy-bridge to demobundle, where it belongs
- [x] See if tests pass
- [x] BC doc
- [x] Cleanup & rebase
- [x] Revert the downgrade merge (ac4f004), and merge ezsystems/ezpublish-kernel#1148, see if tests pass
- [x] List dependencies, and prepare merge battle plan
- [x] Consider rebasing the test improvements to another PR.
