### PR TITLE
EZP-23934: remove legacy bridge

### DIFF
--- a/bin/.travis/add_legacy_composer_scripts.php
+++ b/bin/.travis/add_legacy_composer_scripts.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Adds scripts to post-install-cmd and post-update-cmd composer.json blocks
+ */
+$scripts = [
+    "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installAssets",
+    "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installLegacyBundlesExtensions"
+];
+
+$composer = json_decode( file_get_contents( 'composer.json' ), true );
+foreach ( $scripts as $script )
+{
+    $composer['scripts']['post-update-cmd'][] = $script;
+    $composer['scripts']['post-install-cmd'][] = $script;
+}
+
+file_put_contents( 'composer.json', json_encode( $composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n" );

--- a/bin/.travis/enablelegacybundle.php
+++ b/bin/.travis/enablelegacybundle.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+$kernelPath = 'ezpublish/EzPublishKernel.php';
+
+$kernelContents = file_get_contents( $kernelPath );
+$kernelContents = preg_replace(
+    "/$\s+\);$$\s+switch/m",
+    ",\n            new eZ\Bundle\EzPublishLegacyBundle\EzPublishLegacyBundle( \$this )\n        );\n\n        switch",
+    $kernelContents
+);
+
+file_put_contents( $kernelPath, $kernelContents );

--- a/bin/.travis/prepare_ezpublish.sh
+++ b/bin/.travis/prepare_ezpublish.sh
@@ -5,6 +5,43 @@
 echo "> Setup github auth key to not reach api limit"
 ./bin/.travis/install_composer_github_key.sh
 
+echo "> Add legacy-bridge to requirements"
+composer require --no-update "ezsystems/legacy-bridge:dev-master"
+
+echo "> Configuring legacy"
+php ./bin/.travis/enablelegacybundle.php
+
+## add legacy routes
+cat << EOF >> ezpublish/config/routing.yml
+_ezpublishLegacyRoutes:
+    resource: @EzPublishLegacyBundle/Resources/config/routing.yml
+EOF
+
+## add setup wizard security rule
+cat << EOF >> ezpublish/config/security.yml
+        ezpublish_setup:
+            pattern: ^/ezsetup
+            security: false
+
+EOF
+
+## enable legacy mode on admin siteaccess
+cat << EOF >> ezpublish/config/ezpublish_behat.yml
+ez_publish_legacy:
+    system:
+        behat_site:
+            legacy_mode: false
+        behat_site_admin:
+            legacy_mode: true
+
+EOF
+
+## add legacy post-*-cmd scripts
+php ./bin/.travis/add_legacy_composer_scripts.php
+
+## enable legacy template engine
+sed -i "s/engines: \['twig/engines: ['eztpl', 'twig/" ezpublish/config/config.yml
+
 echo "> Install dependencies through composer"
 composer install --dev --prefer-dist
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "incenteev/composer-parameter-handler": "~2.0",
         "tedivm/stash-bundle": "0.4.*",
         "ezsystems/ezpublish-kernel": "dev-master",
-        "ezsystems/legacy-bridge": "dev-master",
         "ezsystems/platform-ui-bundle": "dev-master",
         "ezsystems/platform-ui-assets-bundle": "~0.1",
         "ezsystems/demobundle": "dev-master",
@@ -48,26 +47,25 @@
         "behat/mink-selenium2-driver": "*",
         "ezsystems/behatbundle": "@dev"
     },
+    "suggest": {
+        "ezsystems/legacy-bridge": "Provides the full legacy backoffice and legacy features"
+    },
     "scripts": {
         "post-install-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
-            "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installAssets",
             "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::dumpAssets",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
-            "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installLegacyBundlesExtensions"
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile"
         ],
         "post-update-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
-            "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installAssets",
             "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::dumpAssetsHelpText",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
-            "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installLegacyBundlesExtensions"
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile"
         ]
     },
     "config": {

--- a/ezpublish/EzPublishKernel.php
+++ b/ezpublish/EzPublishKernel.php
@@ -11,13 +11,11 @@ use Egulias\ListenersDebugCommandBundle\EguliasListenersDebugCommandBundle;
 use eZ\Bundle\EzPublishCoreBundle\EzPublishCoreBundle;
 use eZ\Bundle\EzPublishDebugBundle\EzPublishDebugBundle;
 use eZ\Bundle\EzPublishIOBundle\EzPublishIOBundle;
-use eZ\Bundle\EzPublishLegacyBundle\EzPublishLegacyBundle;
 use eZ\Bundle\EzPublishRestBundle\EzPublishRestBundle;
 use EzSystems\CommentsBundle\EzSystemsCommentsBundle;
 use EzSystems\DemoBundle\EzSystemsDemoBundle;
 use EzSystems\BehatBundle\EzSystemsBehatBundle;
 use eZ\Bundle\EzPublishCoreBundle\Kernel;
-use EzSystems\NgsymfonytoolsBundle\EzSystemsNgsymfonytoolsBundle;
 use EzSystems\PlatformUIBundle\EzSystemsPlatformUIBundle;
 use EzSystems\PlatformUIAssetsBundle\EzSystemsPlatformUIAssetsBundle;
 use FOS\HttpCacheBundle\FOSHttpCacheBundle;
@@ -67,12 +65,10 @@ class EzPublishKernel extends Kernel
             new LiipImagineBundle(),
             new FOSHttpCacheBundle(),
             new EzPublishCoreBundle(),
-            new EzPublishLegacyBundle( $this ),
             new EzPublishIOBundle(),
             new EzSystemsDemoBundle(),
             new EzPublishRestBundle(),
             new EzSystemsCommentsBundle(),
-            new EzSystemsNgsymfonytoolsBundle(),
             new EzSystemsPlatformUIAssetsBundle(),
             new EzSystemsPlatformUIBundle(),
             new WhiteOctoberPagerfantaBundle(),

--- a/ezpublish/config/config.yml
+++ b/ezpublish/config/config.yml
@@ -19,7 +19,7 @@ framework:
     # Place "eztpl" engine first intentionnally.
     # This is to avoid template name parsing with Twig engine, refusing specific characters
     # which are valid with legacy tpl files.
-    templating:      { engines: ['eztpl', 'twig'] } #assets_version: SomeVersionScheme
+    templating:      { engines: ['twig'] } #assets_version: SomeVersionScheme
     default_locale:  "%locale_fallback%"
     trusted_hosts:   ~
     trusted_proxies: ~

--- a/ezpublish/config/ezpublish_behat.yml
+++ b/ezpublish/config/ezpublish_behat.yml
@@ -31,13 +31,6 @@ ezpublish:
             languages: [eng-GB]
             var_dir: var/behat_site
 
-ez_publish_legacy:
-    system:
-        behat_site:
-            legacy_mode: false
-        behat_site_admin:
-            legacy_mode: true
-
 stash:
     caches:
         default:

--- a/ezpublish/config/routing.yml
+++ b/ezpublish/config/routing.yml
@@ -9,9 +9,6 @@ logout:
 _ezpublishRoutes:
     resource: "@EzPublishCoreBundle/Resources/config/routing/internal.yml"
 
-_ezpublishLegacyRoutes:
-    resource: "@EzPublishLegacyBundle/Resources/config/routing.yml"
-
 _ezpublishRestRoutes:
     resource: "@EzPublishRestBundle/Resources/config/routing.yml"
     prefix:   %ezpublish_rest.path_prefix%

--- a/ezpublish/config/security.yml
+++ b/ezpublish/config/security.yml
@@ -10,10 +10,6 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
 
-        ezpublish_setup:
-            pattern: ^/ezsetup
-            security: false
-
 #        ezpublish_rest:
 #            pattern: ^/api/ezp/v2
 #            stateless: true


### PR DESCRIPTION
> See [EZP-23934](https://jira.ez.no/browse/EZP-23934)

Removes legacy-bridge (and ezpublish-legacy) from requirements.

## Doc
### Re-installing legacy
Legacy can be (re-)installed by adding ezsystems/legacy-bridge to the dependencies. It requires `ezsystems/ezpublish-legacy`, and will automatically install it.

## Changes to tests
In order to pass tests, legacy is still required, be it only for the wizard.
The test setup was enhanced (see `bin/.travis/prepare_ezpublish.sh`) to:
- require legacy-bridge (using composer)
- enable it in EzPublishKernel (using a tiny php script)

## TODO
- [x] Temporary: merge commits from #223 so that the changes are actually relevant
- [ ] BC/Upgrade doc
- [x] Merge #223 
