### PR TITLE
Fixed composer dependency issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,6 @@
         "behat/sahi-client": "dev-master as 1.1.1",
         "behat/mink-extension": "*",
         "behat/mink-goutte-driver": "*",
-        "behat/mink-selenium-driver": "*",
         "behat/mink-sahi-driver": "*",
         "behat/mink-selenium2-driver": "*",
         "ezsystems/behatbundle": "@dev"


### PR DESCRIPTION
Fixes the *very* annoying issue avoiding to do composer install/update, with a huge output saying it cannot install Symfony.
Seems to be caused by selenium (v1) mink driver which depends on Mink 1.4, which depends on Symfony <2.4.