### PR TITLE
Platform reverts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ php:
 # list of paths/bundle to execute
 env:
   - INSTALL="demoContentNonUniqueDB" PROFILE="demo" TEST="content"
-  - PROFILE="demo" TEST="clean"
-  - PROFILE="rest" TEST="fullJson"
-  - PROFILE="rest" TEST="fullXml"
+  - INSTALL="demoContentNonUniqueDB" PROFILE="demo" TEST="clean"
+  - INSTALL="demoCleanNonUniqueDB" PROFILE="rest" TEST="fullJson"
+  - INSTALL="demoCleanNonUniqueDB" PROFILE="rest" TEST="fullXml"
 
 
 # test only master (+ Pull requests)
@@ -30,7 +30,7 @@ before_script:
 
 # execute behat as the script command
 script:
-  - php bin/behat -vv --profile $PROFILE --suite $TEST
+  - php bin/behat --profile $PROFILE --suite $TEST
 
 # disable mail notifications
 notification:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
 
 # execute behat as the script command
 script:
-  - php bin/behat --profile $PROFILE --suite $TEST
+  - php bin/behat -vv --profile $PROFILE --suite $TEST
 
 # disable mail notifications
 notification:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ php:
 
 # list of paths/bundle to execute
 env:
+    # run setup wizard to install Demo+Content and then test demo with content
   - INSTALL="demoContentNonUniqueDB" PROFILE="demo" TEST="content"
-  - INSTALL="demoContentNonUniqueDB" PROFILE="demo" TEST="clean"
+    # test Legacy
+  - INSTALL="demoCleanNonUniqueDB" PROFILE="legacyAdmin" TEST="full"
+    # test REST
   - INSTALL="demoCleanNonUniqueDB" PROFILE="rest" TEST="fullJson"
   - INSTALL="demoCleanNonUniqueDB" PROFILE="rest" TEST="fullXml"
 
@@ -27,6 +30,10 @@ before_install:
 before_script:
   # Prepare eZ Publish (composer, permissions, assets, cache warmup)
   - ./bin/.travis/prepare_ezpublish.sh
+  # since setup wizard need to actually work to the other test suites to pass
+  # moved it to before_script so that the random timeout on package fetching
+  # don't fail travis
+  - php bin/behat --profile setupWizard --suite $INSTALL
 
 # execute behat as the script command
 script:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,34 +1,53 @@
 # Installation instructions
 
-  These are instructions for installing via GIT (development version), look in INSTALL_ARCHIVE.md for instructions on how to install a eZ Platform build/archive.
+  These are instructions for installing via GIT (development version), look in INSTALL_ARCHIVE.md for instructions on how to install a eZ Publish 5 build/archive.
 
 ## Paths for future reference
-  * `/<root-dir>/`: The filesystem path where eZ Platform is installed in
+  * `/<ezpublish-community-root-dir>/`: The filesystem path where eZ Publish 5 is installed in
 
-    Examples: `/home/myuser/www/` or `/var/sites/<project-name>/`
+    Examples: `/home/myuser/www/` or `/var/sites/ezpublish/`
+  * `/<ezpublish-community-root-dir>/ezpublish_legacy/`: **Legacy** aka **Legacy Stack** refers to the eZ Publish 4.x installation which is bundled with eZ Publish 5 inside `ezpublish_legacy/`
 
-  * `/<root-dir>/web/`: A directory meant to be the **DocumentRoot** of the eZ Platform installation (`<root-dir>` is not supposed to be _readable_ from web server perspective)
+    Examples: `/home/myuser/www/ezpublish_legacy/` or `/var/sites/ezpublish/ezpublish_legacy/`
+  * `/<ezpublish-community-root-dir>/web/`: A directory meant to be the **DocumentRoot** of the eZ Publish 5.x installation (`ezpublish` & `ezpublish_legacy` are not supposed to be _viewable_ from user perspective)
 
-    Examples: `/home/myuser/www/web/` or `/var/sites/<project-name>/web/`
+    Examples: `/home/myuser/www/web/` or `/var/sites/ezpublish/web/`
 
-## Clean install
+## Install all components
 
-1. You can get eZ Platform using composer with the following commands:
+1. You can get eZ Publish using GIT with the following command:
 
        ```bash
-       curl -s http://getcomposer.org/installer | php
-       php -d memory_limit=-1 composer.phar create-project --no-dev --prefer-dist ezsystems/ezpublish-community <directory> <version>
-       cd /<directory>/
+       git clone https://github.com/ezsystems/ezpublish-community.git
        ```
-       
-      Options:
-      - `<version>`: `dev-master` to get current development version (pre release), `v2015.01` to pick a specific release, otherwise skip it to get latest stable release.
-      - For core development change '--prefer-dist' to '--prefer-source' to get full git clones, and remove '--no-dev' to get things like phpunit and behat installed.
 
-  After running command above, composer will take its time to download all libraries, then a wizard will ask you for setting to database and lastly a welcome screen should grant you instructions for finishing installation.
+2. *Optional* Upgrade an eZ Publish installation
 
+       Follow normal eZ Publish upgrade procedures for upgrading the distribution files and moving over extensions as found for instance here:
+       http://doc.ez.no/eZ-Publish/Upgrading/Upgrading-to-5.0/Upgrading-from-4.7-to-5.0
 
-2. Setup folder rights **For *NIX users**:
+3. Install the dependencies with [Composer](http://getcomposer.org).
+
+       **Note: The following step will also install assets, if you prefer to install assets using hard copy or symlink
+               instead of default relative symlink, edit 'symfony-assets-install' setting in composer.json**
+
+       **Dev: For dev use change '--prefer-dist' for '--prefer-source' to get full git clones
+              and add '--dev' to get phpunit and behat installed.**
+
+       Download composer and install dependencies by running:
+       ```bash
+       cd /<ezpublish-community-root-dir>/
+       curl -s http://getcomposer.org/installer | php
+       php -d memory_limit=-1 composer.phar install --prefer-dist
+       ```
+
+       Update note: Every time you want to get the latest updates of all your dependencies just run this command:
+       ```bash
+       cd /<ezpublish-community-root-dir>/
+       php -d memory_limit=-1 composer.phar update --prefer-dist
+       ```
+
+4. Setup folder rights **For *NIX users**:
 
        One common issue is that the `ezpublish/cache`, `ezpublish/logs` and `ezpublish/config` directories **must be writable both by the web server and the command line user**.
        If your web server user is different from your command line user, you can run the following commands just once in your project to ensure that permissions will be set up properly.
@@ -38,11 +57,13 @@
        A. **Using ACL on a system that supports chmod +a**
 
        ```bash
-       $ rm -rf ezpublish/cache/* ezpublish/logs/* ezpublish/sessions/*
+       $ rm -rf ezpublish/cache/*
+       $ rm -rf ezpublish/logs/*
+       $ rm -rf ezpublish/sessions/*
        $ sudo chmod +a "www-data allow delete,write,append,file_inherit,directory_inherit" \
-         ezpublish/{cache,logs,config,sessions} web
+         ezpublish/{cache,logs,config,sessions} ezpublish_legacy/{design,extension,settings,var} web
        $ sudo chmod +a "`whoami` allow delete,write,append,file_inherit,directory_inherit" \
-         ezpublish/{cache,logs,config,sessions} web
+         ezpublish/{cache,logs,config,sessions} ezpublish_legacy/{design,extension,settings,var} web
        ```
 
        B. **Using ACL on a system that does not support chmod +a**
@@ -51,9 +72,9 @@
 
        ```bash
        $ sudo setfacl -R -m u:www-data:rwx -m u:www-data:rwx \
-         ezpublish/{cache,logs,config,sessions} web
+         ezpublish/{cache,logs,config,sessions} ezpublish_legacy/{design,extension,settings,var} web
        $ sudo setfacl -dR -m u:www-data:rwx -m u:`whoami`:rwx \
-         ezpublish/{cache,logs,config,sessions} web
+         ezpublish/{cache,logs,config,sessions} ezpublish_legacy/{design,extension,settings,var} web
        ```
 
        C. **Using chown on systems that don't support ACL**
@@ -61,9 +82,9 @@
        Some systems don't support ACL at all. You will either need to set your web server's user as the owner of the required directories.
 
        ```bash
-       $ sudo chown -R www-data:www-data ezpublish/{cache,logs,config,sessions} web
-       $ sudo find {ezpublish/{cache,logs,config,sessions},web} -type d | sudo xargs chmod -R 775
-       $ sudo find {ezpublish/{cache,logs,config},web} -type f | sudo xargs chmod -R 664
+       $ sudo chown -R www-data:www-data ezpublish/{cache,logs,config,sessions} ezpublish_legacy/{design,extension,settings,var} web
+       $ sudo find {ezpublish/{cache,logs,config,sessions},ezpublish_legacy/{design,extension,settings,var},web} -type d | sudo xargs chmod -R 775
+       $ sudo find {ezpublish/{cache,logs,config},ezpublish_legacy/{design,extension,settings,var},web} -type f | sudo xargs chmod -R 664
        ```
 
        D. **Using chmod**
@@ -71,28 +92,32 @@
        If you can't use ACL and aren't allowed to change owner, you can use chmod, making the files writable by everybody. Note that this method really isn't recommended as it allows any user to do anything.
 
        ```bash
-       $ sudo find {ezpublish/{cache,logs,config,sessions},web} -type d | sudo xargs chmod -R 777
-       $ sudo find {ezpublish/{cache,logs,config,sessions},web} -type f | sudo xargs chmod -R 666
+       $ sudo find {ezpublish/{cache,logs,config,sessions},ezpublish_legacy/{design,extension,settings,var},web} -type d | sudo xargs chmod -R 777
+       $ sudo find {ezpublish/{cache,logs,config,sessions},ezpublish_legacy/{design,extension,settings,var},web} -type f | sudo xargs chmod -R 666
        ```
-
-# Updating
-
-  Every time you want to get the latest updates of all your dependencies just run this command:
-
-  ```bash
-  $ cd /<root-dir>/
-  $ php -d memory_limit=-1 composer.phar update --prefer-dist
-  ```
-
-# Upgrading
-
-  Upgrade instructions are not written yet, they will before final version of eZ Platform. In the meantime follow upgrade instructions for eZ Publish 5.x as a guide if you already want to test your Platform code from 5.x on eZ Platform:
-  http://doc.ez.no/eZ-Platform/Upgrading/Upgrading-to-5.0/Upgrading-from-4.7-to-5.0
-
 
 ## Configure the system
 
-1. *Optional* Dump your assets in your webroot:
+1. *Optional* Upgrade Configuration: Generate eZ Publish 5 yml configuration
+
+       **Note: this step in only valid for upgrades and can be ignored if you intend to run the setup wizard.**
+
+       To generate yml configuration for the new Symfony stack a console command has been provided to
+       cover single site setups.
+
+       Perform the following command where `<group>` is the siteaccess group name, for instance package name like
+       'ezdemo_site', 'ezwebin_site' or 'ezflow_site'. And `<admin_siteaccess>` is, for instance, 'ezdemo_site_admin':
+
+       ```bash
+       cd /<ezpublish-community-root-dir>/
+       php ezpublish/console ezpublish:configure --env=prod <group> <admin_siteaccess>
+       ```
+
+       If you instead would like to manually create your yml config, do the following:
+       * Copy `ezpublish/config/ezpublish.yml.example` to `ezpublish/config/ezpublish_prod.yml`
+       * Edit `ezpublish/config/ezpublish_prod.yml`
+
+2. *Optional* Dump your assets in your webroot:
 
       This step is optional as it is automatically done for you when you install / update vendors via composer which
       you did a few steps up. However during development you will need to execute these (especially last one) to get
@@ -100,10 +125,15 @@
 
        ```bash
        php ezpublish/console assets:install --symlink web
+       php ezpublish/console ezpublish:legacy:assets_install --symlink web
        php ezpublish/console assetic:dump --env=prod web
        ```
        The first command will symlink all the assets from your bundles in the `web/` folder, in a `bundles/` sub-folder.
-       The second command will generate the CSS and JavaScript files for the *prod* environement.
+
+       The second command will symlink assets from your eZ Publish legacy directory and add wrapper scripts around the legacy front controllers
+       (basically `index_treemenu.php`, `index_rest.php` and `index_cluster.php`)
+
+       The third command will generate the CSS and JavaScript files for the *prod* environement.
 
        In those commands, "web" is the default folder. In the first two commands, --relative can be added for relative symlinks and further help is available with -h.
 
@@ -111,14 +141,35 @@
        ```bash
        $ sudo -u www-data php ezpublish/console assets:install --symlink web
        ```
-       **Note:(2)** if you are deploying ez platform on windows 7+, you need to run the command as Administrator to avoid the following error:
+       **Note:(2)** if you are deploying ez publish 5 on windows 7+, you need to run the command as Administrator to avoid the following error:
 
        > [Symfony\Component\Filesystem\Exception\IOException]
        > Unable to create symlink due to error code 1314: 'A required privilege is not held by the client'. Do you have the required Administrator-rights?
        > This is the first solution. But you can also edit the composer.json file by changing "symfony-assets-install": "symlink" to "symfony-assets-install": ""
 
-2. *Optional* Configure a VirtualHost:
+3. *Optional* Configure a VirtualHost:
 
     See: https://confluence.ez.no/display/EZP/Virtual+host+setup
 
+4. Run the Setup wizard:
+
+  **Note: this step in only valid for clean install and can be ignored if you are performing an upgrade.**
+
+  In Virtual host mode access http://`<your-host-name>`/ezsetup to trigger the setup wizard.
+  In Non-Virtual Host mode access eZ Publish like: http://localhost/ezp5/index.php/ezsetup
+
+  **Troubleshooting during Setup wizard**
+
+  You might get the following error:
+  > Retrieving remote site packages list failed. You may upload packages manually.
+  >
+  > Remote repository URL: http://packages.ez.no/ezpublish/5.0/5.0.0[-alpha1]/
+
+  This should only happen when you install from GIT or use pre-release packages
+  To fix it, tweak your `ezpublish_legacy/settings/package.ini` by overriding it with latest valid version, for example:
+
+  ```ini
+  [RepositorySettings]
+  RemotePackagesIndexURL=http://packages.ez.no/ezpublish/5.0/5.0.0
+  ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,9 +57,7 @@
        A. **Using ACL on a system that supports chmod +a**
 
        ```bash
-       $ rm -rf ezpublish/cache/*
-       $ rm -rf ezpublish/logs/*
-       $ rm -rf ezpublish/sessions/*
+       $ rm -rf ezpublish/cache/* ezpublish/logs/* ezpublish/sessions/*
        $ sudo chmod +a "www-data allow delete,write,append,file_inherit,directory_inherit" \
          ezpublish/{cache,logs,config,sessions} ezpublish_legacy/{design,extension,settings,var} web
        $ sudo chmod +a "`whoami` allow delete,write,append,file_inherit,directory_inherit" \

--- a/behat.yml
+++ b/behat.yml
@@ -50,9 +50,6 @@ demo:
         content:
             paths: [ vendor/ezsystems/demobundle/EzSystems/DemoBundle/Features/Content ]
             contexts: [ EzSystems\DemoBundle\Features\Context\Content\Context ]
-        clean:
-            paths: [ vendor/ezsystems/demobundle/EzSystems/DemoBundle/Features/Clean ]
-            contexts: [ EzSystems\DemoBundle\Features\Context\Demo ]
 
 legacyAdmin:
     extensions:

--- a/bin/.travis/parameters.yml
+++ b/bin/.travis/parameters.yml
@@ -1,5 +1,0 @@
-# This file only contains settings different then defaults in parameters.yml.dist
-parameters:
-    database_name: behattestdb
-    database_user: ezp
-    database_password: ezp

--- a/bin/.travis/prepare_ezpublish.sh
+++ b/bin/.travis/prepare_ezpublish.sh
@@ -9,8 +9,8 @@ echo "> Install dependencies through composer"
 composer install -n --prefer-dist
 
 echo "> Set folder permissions"
-sudo find {ezpublish/{cache,logs,config,sessions},web} -type d | sudo xargs chmod -R 777
-sudo find {ezpublish/{cache,logs,config,sessions},web} -type f | sudo xargs chmod -R 666
+sudo find {ezpublish/{cache,logs,config,sessions},ezpublish_legacy/{design,extension,settings,var},web} -type d | sudo xargs chmod -R 777
+sudo find {ezpublish/{cache,logs,config,sessions},ezpublish_legacy/{design,extension,settings,var},web} -type f | sudo xargs chmod -R 666
 
 echo "> Run assetic dump for behat env"
 php ezpublish/console --env=behat assetic:dump

--- a/bin/.travis/prepare_ezpublish.sh
+++ b/bin/.travis/prepare_ezpublish.sh
@@ -11,8 +11,8 @@ cp bin/.travis/parameters.yml ezpublish/config/
 echo "> Install dependencies through composer"
 composer install -n --prefer-dist
 
-if [ "$INSTALL" = "demoContentNonUniqueDB" ] ; then
-  echo "> Install ezplatform demo-content"
+if [ "$TEST" = "content" ] ; then
+  echo "> Install ezplatform demo"
   php ezpublish/console ezplatform:install demo
 else
   echo "> Install ezplatform clean"

--- a/bin/.travis/prepare_ezpublish.sh
+++ b/bin/.travis/prepare_ezpublish.sh
@@ -5,19 +5,8 @@
 echo "> Setup github auth key to not reach api limit"
 ./bin/.travis/install_composer_github_key.sh
 
-echo "> Copy behat specific parameters.yml settings"
-cp bin/.travis/parameters.yml ezpublish/config/
-
 echo "> Install dependencies through composer"
 composer install -n --prefer-dist
-
-if [ "$TEST" = "content" ] ; then
-  echo "> Install ezplatform demo"
-  php ezpublish/console ezplatform:install demo
-else
-  echo "> Install ezplatform clean"
-  php ezpublish/console ezplatform:install clean
-fi
 
 echo "> Set folder permissions"
 sudo find {ezpublish/{cache,logs,config,sessions},web} -type d | sudo xargs chmod -R 777

--- a/bin/.travis/prepare_system.sh
+++ b/bin/.travis/prepare_system.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Script to do tasks before install, can install system packages / software
 ## See http://about.travis-ci.org/docs/user/build-configuration/
@@ -9,7 +9,10 @@
 ##       https://github.com/facebook/hiphop-php/commit/0b2dfdf4492eb06a125b068e939d092ec0588e5c
 
 # Disable xdebug to speed things up
-phpenv config-rm xdebug.ini
+if [[ "$USE_DEBUGGING" == "" && "$TRAVIS_PHP_VERSION" != "" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then
+    echo "> Disable xdebug";
+    phpenv config-rm xdebug.ini ;
+fi
 
 # Install needed packages
 echo "> Installing needed packages";

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "tedivm/stash-bundle": "0.4.*",
         "ezsystems/ezpublish-kernel": "dev-master",
         "ezsystems/legacy-bridge": "dev-master",
+        "ezsystems/ngsymfonytools-bundle": "dev-master",
         "ezsystems/platform-ui-bundle": "dev-master",
         "ezsystems/platform-ui-assets-bundle": "~0.2",
         "ezsystems/demobundle": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "incenteev/composer-parameter-handler": "~2.0",
         "tedivm/stash-bundle": "0.4.*",
         "ezsystems/ezpublish-kernel": "dev-master",
+        "ezsystems/legacy-bridge": "dev-master",
         "ezsystems/platform-ui-bundle": "dev-master",
         "ezsystems/platform-ui-assets-bundle": "~0.2",
         "ezsystems/demobundle": "dev-master",
@@ -47,25 +48,26 @@
         "behat/mink-selenium2-driver": "*",
         "ezsystems/behatbundle": "@dev"
     },
-    "suggest": {
-        "ezsystems/legacy-bridge": "Provides the full legacy backoffice and legacy features"
-    },
     "scripts": {
         "post-install-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
+            "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installAssets",
             "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::dumpAssets",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile"
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
+            "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installLegacyBundlesExtensions"
         ],
         "post-update-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
+            "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installAssets",
             "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::dumpAssetsHelpText",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile"
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
+            "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installLegacyBundlesExtensions"
         ]
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -64,11 +64,8 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
-            "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::dumpAssetsHelpText"
-        ],
-        "post-create-project-cmd": [
-            "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::installWelcomeText"
+            "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::dumpAssetsHelpText",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile"
         ]
     },
     "config": {

--- a/doc/nginx/etc/nginx/sites-available/mysite.com
+++ b/doc/nginx/etc/nginx/sites-available/mysite.com
@@ -26,6 +26,9 @@ server {
     # ez rewrite rules
     include ez_params.d/ez_rewrite_params;
 
+    # upload max size
+    client_max_body_size 2m;
+
     location / {
         location ~ ^/(index|index_(rest|cluster|treemenu_tags))\.php(/|$) {
             include ez_params.d/ez_fastcgi_params;

--- a/ezpublish/EzPublishKernel.php
+++ b/ezpublish/EzPublishKernel.php
@@ -12,11 +12,13 @@ use eZ\Bundle\EzPublishCoreBundle\EzPublishCoreBundle;
 use eZ\Bundle\EzPublishLegacySearchEngineBundle\EzPublishLegacySearchEngineBundle;
 use eZ\Bundle\EzPublishDebugBundle\EzPublishDebugBundle;
 use eZ\Bundle\EzPublishIOBundle\EzPublishIOBundle;
+use eZ\Bundle\EzPublishLegacyBundle\EzPublishLegacyBundle;
 use eZ\Bundle\EzPublishRestBundle\EzPublishRestBundle;
 use EzSystems\CommentsBundle\EzSystemsCommentsBundle;
 use EzSystems\DemoBundle\EzSystemsDemoBundle;
 use EzSystems\BehatBundle\EzSystemsBehatBundle;
 use eZ\Bundle\EzPublishCoreBundle\Kernel;
+use EzSystems\NgsymfonytoolsBundle\EzSystemsNgsymfonytoolsBundle;
 use EzSystems\PlatformUIBundle\EzSystemsPlatformUIBundle;
 use EzSystems\PlatformUIAssetsBundle\EzSystemsPlatformUIAssetsBundle;
 use FOS\HttpCacheBundle\FOSHttpCacheBundle;
@@ -69,10 +71,12 @@ class EzPublishKernel extends Kernel
             new FOSHttpCacheBundle(),
             new EzPublishCoreBundle(),
             new EzPublishLegacySearchEngineBundle(),
+            new EzPublishLegacyBundle( $this ),
             new EzPublishIOBundle(),
             new EzSystemsDemoBundle(),
             new EzPublishRestBundle(),
             new EzSystemsCommentsBundle(),
+            new EzSystemsNgsymfonytoolsBundle(),
             new EzSystemsPlatformUIAssetsBundle(),
             new EzSystemsPlatformUIBundle(),
             new WhiteOctoberPagerfantaBundle(),

--- a/ezpublish/config/config.yml
+++ b/ezpublish/config/config.yml
@@ -19,7 +19,7 @@ framework:
     # Place "eztpl" engine first intentionnally.
     # This is to avoid template name parsing with Twig engine, refusing specific characters
     # which are valid with legacy tpl files.
-    templating:      { engines: ['twig'] } #assets_version: SomeVersionScheme
+    templating:      { engines: ['eztpl', 'twig'] } #assets_version: SomeVersionScheme
     default_locale:  "%locale_fallback%"
     trusted_hosts:   ~
     trusted_proxies: ~

--- a/ezpublish/config/config.yml
+++ b/ezpublish/config/config.yml
@@ -2,17 +2,6 @@ imports:
     - { resource: parameters.yml }
     - { resource: security.yml }
 
-doctrine:
-    dbal:
-        connections:
-            default:
-                driver: %database_driver%
-                host: %database_host%
-                user: %database_user%
-                password: %database_password%
-                dbname: %database_name%
-                charset: UTF8
-
 framework:
     esi:             ~
     translator:      { fallback: "%locale_fallback%" }

--- a/ezpublish/config/ezpublish_behat.yml
+++ b/ezpublish/config/ezpublish_behat.yml
@@ -1,2 +1,39 @@
-imports:
-    - {resource: ezpublish_prod.yml}
+doctrine:
+    dbal:
+        connections:
+            default:
+                driver: pdo_mysql
+                host: localhost
+                user: root
+                dbname: behattestdb
+                charset: UTF8
+
+ezpublish:
+    repositories:
+        behat: ~
+    siteaccess:
+        # Available siteaccesses
+        list:
+            - behat_site
+            - behat_site_admin
+        # Siteaccess groups. Use them to group common settings.
+        groups:
+            behat_group: [behat_site, behat_site_admin]
+        default_siteaccess: behat_site
+        match:
+            Map\URI:
+                behat_site_admin: behat_site_admin
+            Map\Host:
+                localhost: behat_site
+    system:
+        behat_group:
+            repository: behat
+            languages: [eng-GB]
+            var_dir: var/behat_site
+
+stash:
+    caches:
+        default:
+            drivers: [ FileSystem ]
+            inMemory: true
+            registerDoctrineAdapter: false

--- a/ezpublish/config/ezpublish_behat.yml
+++ b/ezpublish/config/ezpublish_behat.yml
@@ -31,6 +31,13 @@ ezpublish:
             languages: [eng-GB]
             var_dir: var/behat_site
 
+ez_publish_legacy:
+    system:
+        behat_site:
+            legacy_mode: false
+        behat_site_admin:
+            legacy_mode: true
+
 stash:
     caches:
         default:

--- a/ezpublish/config/ezpublish_setup.yml
+++ b/ezpublish/config/ezpublish_setup.yml
@@ -1,10 +1,27 @@
+doctrine:
+    dbal:
+        connections:
+            default:
+                driver: pdo_mysql
+                host: localhost
+                user: root
+                dbname: none
+
 ezpublish:
+    repositories:
+        setup: ~
     siteaccess:
-        list: ['setup']
+        # Available siteaccesses
+        list:
+            - setup
+        # Siteaccess groups. Use them to group common settings.
         groups: []
-        default_siteaccess: 'setup'
-        match:
-            URIElement: '1'
+        default_siteaccess: setup
+        match: {}
+
+    system:
+        setup:
+            languages: []
 
 stash:
     caches:

--- a/ezpublish/config/parameters.yml.dist
+++ b/ezpublish/config/parameters.yml.dist
@@ -8,10 +8,3 @@ parameters:
     mailer_host:       127.0.0.1
     mailer_user:       ~
     mailer_password:   ~
-
-    database_driver: pdo_mysql
-    database_host: localhost
-    database_port: 3306
-    database_name: ezplatform
-    database_user: root
-    database_password:

--- a/ezpublish/config/routing.yml
+++ b/ezpublish/config/routing.yml
@@ -9,6 +9,9 @@ logout:
 _ezpublishRoutes:
     resource: "@EzPublishCoreBundle/Resources/config/routing/internal.yml"
 
+_ezpublishLegacyRoutes:
+    resource: "@EzPublishLegacyBundle/Resources/config/routing.yml"
+
 _ezpublishRestRoutes:
     resource: "@EzPublishRestBundle/Resources/config/routing.yml"
     prefix:   %ezpublish_rest.path_prefix%

--- a/ezpublish/config/security.yml
+++ b/ezpublish/config/security.yml
@@ -10,6 +10,10 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
 
+        ezpublish_setup:
+            pattern: ^/ezsetup
+            security: false
+
 #        ezpublish_rest:
 #            pattern: ^/api/ezp/v2
 #            stateless: true


### PR DESCRIPTION
To get ezpublish-community back to working state we need to do some reverts, however there where some improvements during the transition to ezplatform that we should try to keep so they are somewhat in sync (eases maintenance).

- <del>Consider keeping the parameters.yml changes, however they might just conflict with legacy setup wizard</del>

