### PR TITLE
Fix EZP-24311: Clarify the differences between ezpublish-community and ezplatform repositories in README.md documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ eZ Publish exists in two versions; this, the community version is available unde
 the GPLv2 license, while several extended versions for enterprise & business is available
 under a more permissive business license, see [ez.no](http://ez.no/) for more info.
 
+## eZ Publish / eZ Platform
+This repository contains the eZ Publish 5 dual kernel. It integrates eZ Publish Legacy, unlike the next product generation, [eZ Platform](https://github.com/ezsystems/ezplatform). This repository is mostly maintained for backwards compatibility.
+
+eZ Platform, formerly eZ Publish 6, uses the same Symfony kernel than eZ Publish 5, but does not include the legacy application, nor the dependent libraries. eZ Platform is where the new features are added.
+
 ## Install, Upgrade and Getting started
 For installation & upgrade instructions, see [INSTALL.md](https://github.com/ezsystems/ezpublish-community/blob/master/INSTALL.md).
 


### PR DESCRIPTION
Hello,

Related issue for these pull requests: https://jira.ez.no/browse/EZP-24311

Per request from Andre to update the repository README.md documentation to clarify the differences between the older ezpublish-community repository and the new ezplatform repository in order to re-start community builds for the 5.x branch we are creating this issue.

Goal: Clarify the differences between the older ezpublish-community repository and the new ezplatform repository in repository README.md documentation.

To achieve this goal we will update the README.md documentation in each repository via separate pull requests to explain the main difference (today) between each repository is the inclusion or exclusion of legacy dependencies by default.


This pull request addresses the issue in question for this repository. 
Another pull request exists for the other repository. 
See issue ticket for alternate pull request links.

Please let us know how this finds you.

Thank you again for your continued support.

Cheers,
Brookins Consulting