### PR TITLE
Fix EZP-24312: Default installation content results in 404 errors

### DIFF
--- a/doc/apache2/vhost.template
+++ b/doc/apache2/vhost.template
@@ -91,6 +91,11 @@
         #RewriteRule ^/var/([^/]+/)?storage/images(-versioned)?/.* /index_cluster.php [L]
         #RewriteRule ^/var/([^/]+/)?cache/(texttoimage|public)/.* /index_cluster.php [L]
 
+        # If using default installation of demobundle or linking to uploaded binary file content, you may wish to uncomment the following two lines:
+        # These lines represent a temporary bugfix and also a potential security issue which is documented here: https://jira.ez.no/browse/EZP-24312
+        #RewriteRule ^/var/storage/.* - [L]
+        #RewriteRule ^/var/[^/]+/storage/.* - [L]
+
         RewriteRule ^/var/([^/]+/)?storage/images(-versioned)?/.* - [L]
         RewriteRule ^/var/([^/]+/)?cache/(texttoimage|public)/.* - [L]
         RewriteRule ^/design/[^/]+/(stylesheets|images|javascript|fonts)/.* - [L]


### PR DESCRIPTION
Hello,

This issue and PR are a direct result of testing the latest / recent ezpublish-community repository reverts / changes for default installation errors and any other problems which might be blockers for the creation of the next ezpublish-community eZ Publish 5 community build, currently in preparation phase.

The default installation of ezpublish-community using demobundle and ezdemo ezpackage content which provides selected video content results in 404 errors on default index page.

This is a temporary problem for both eZ Publish 5.x and eZ Platform.

This is direct result of the ezpublish-kernel not yet providing a new stack (Symfony) based replacement for the content/download module view which is required to abstract the serving of binary file content object content.

The problem is that the demobundle and ezdemo extension provided default content during a default installation make use of binary file content which requires these mod_rewrite rules be in your virtual host configuration ... or a default installation described will generate 404 errors when loading the index page of the default user siteaccess.

The 404 errors can be solved today by editing your virtual host configuration mod_rewrite rules and adding the new rules provided by this PR, commented out by default. 

This PR provides for the education to developers on this important issue which has for some time now generated page load 404 errors (and large amounts of confusion to developers and users) while retaining the maximum security in a default installation.

This issue has been uniquely documented here: https://jira.ez.no/browse/EZP-24312

Please let us know your thoughts.

Cheers,
Brookins Consulting