### PR TITLE
Fix EZP-24313: Assets for dev environment being served from disk in Apache

### DIFF
--- a/doc/apache2/vhost.template
+++ b/doc/apache2/vhost.template
@@ -127,7 +127,7 @@
 
         # Additional Assetic rules for environments different from dev,
         # remember to run php ezpublish/console assetic:dump --env=prod
-        RewriteCond %{ENV:ENVIRONMENT} !("dev")
+        RewriteCond %{ENV:ENVIRONMENT} !^(dev)
         RewriteRule ^/(css|js|font)/.*\.(css|js|otf|eot|ttf|svg|woff) - [L]
 
         # Conditions for enabling webdav and soap interfaces from legacy


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24313

#### Problem:
Rewrite condition for serving assets from file is also executed for the `dev` environment, which should not be the case, as it results in `404 Not Found` unless assets are dumped for `dev`.

#### Tests:
Manual in Apache 2.2.22 and 2.4.7