### PR TITLE
EZP-24278: removed legacy rewrite rule for REST API v1

### DIFF
--- a/doc/apache2/vhost.template
+++ b/doc/apache2/vhost.template
@@ -80,9 +80,6 @@
         RewriteCond %{REQUEST_URI} ^/php5-fcgi(.*)
         RewriteRule . - [L]
 
-        # v1 rest API is on Legacy
-        RewriteRule ^/api/[^/]+/v1/ /index_rest.php [L]
-
         # If using cluster, uncomment the following two lines:
         ## For 5.4 and higher:
         #RewriteRule ^/var/([^/]+/)?storage/images(-versioned)?/.* /index.php [L]

--- a/doc/nginx/etc/nginx/ez_params.d/ez_rewrite_params
+++ b/doc/nginx/etc/nginx/ez_params.d/ez_rewrite_params
@@ -2,9 +2,6 @@
 rewrite "^tags/treemenu/?" "index_treemenu_tags.php" last;
 rewrite "^index_treemenu_tags\.php" "/index_treemenu_tags.php" last;
 
-# v1 rest API is on Legacy
-rewrite "^/api/[^/]+/v1" "/index_rest.php" last;
-
 rewrite "^/var/([^/]+/)?storage/images(-versioned)?/(.*)" "/var/$1storage/images$2/$3" break;
 rewrite "^/var/([^/]+/)?cache/(texttoimage|public)/(.*)" "/var/$1cache/$2/$3" break;
 rewrite "^/design/([^/]+)/(stylesheets|images|javascript|fonts)/(.*)" "/design/$1/$2/$3" break;


### PR DESCRIPTION
> Rewrite rules update for http://jira.ez.no/browse/EZP-24278