### PR TITLE
Add missing /web/css and /web/js to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,10 @@
 /web/index_rest.php
 /web/index_cluster.php
 /web/bundles/
+/web/css
 /web/design
 /web/extension
+/web/js
 /web/share
 /web/var
 /web/.htaccess


### PR DESCRIPTION
These folders are created by assets:install and therefore shouldn't be added to version control when created.
