### PR TITLE
Fix EZP-27285: Prevent access to website with direct usage of index.php in URL

### DIFF
--- a/doc/apache2/vhost.template
+++ b/doc/apache2/vhost.template
@@ -138,6 +138,9 @@
         #RewriteCond %{ENV:ENVIRONMENT} "dev"
         #RewriteRule .* /index_dev.php [L]
 
+        # Prevent access to website with direct usage of app.php in URL
+        RewriteRule ^/(.+/)?index\.php - [R=404,L]
+
         RewriteRule .* /index.php
     </IfModule>
 

--- a/doc/nginx/etc/nginx/ez_params.d/ez_rewrite_params
+++ b/doc/nginx/etc/nginx/ez_params.d/ez_rewrite_params
@@ -35,5 +35,10 @@ rewrite "^/w3c/p3p\.xml" "/w3c/p3p.xml" break;
 # Following rule is needed to correctly display assets from eZ Publish5 / Symfony bundles
 rewrite "^/bundles/(.*)" "/bundles/$1" break;
 
+# Prevent access to website with direct usage of index.php in URL
+if ($request_uri ~ "^/(.+/)?index\.php") {
+    return 404;
+}
+
 rewrite "^(.*)$" "/index.php$1" last;
 


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27285

# Description

This PR change default configuration of URL Rewrite Engine which currently allows access to EZP based websites with direct usage of `index.php` in URL e.g. 

* http://exemple.com/index.php
* http://example.com/anything/you/want/index.php

Besides of non-loaded assets, it may impact on SEO because of [content duplication](https://support.google.com/webmasters/answer/66359?hl=en).

In similar to eZ Platform: access is prevented by 404 response when URL contains `index.php` 